### PR TITLE
Feat/rust security core

### DIFF
--- a/fasthttp/_core/src/headers.rs
+++ b/fasthttp/_core/src/headers.rs
@@ -1,0 +1,103 @@
+use once_cell::sync::Lazy;
+use pyo3::prelude::*;
+use std::collections::{HashMap, HashSet};
+
+static DANGEROUS_RESPONSE_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    HashSet::from([
+        "x-accel-redirect",
+        "x-sendfile",
+        "x-accel-limit-rate",
+        "x-ratelimit-limit",
+        "x-ratelimit-remaining",
+        "refresh",
+        "content-security-policy",
+        "content-security-policy-report-only",
+    ])
+});
+
+static BLOCKED_REQUEST_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    HashSet::from([
+        "host",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "upgrade",
+    ])
+});
+
+#[inline]
+fn has_crlf(s: &str) -> bool {
+    s.contains('\r') || s.contains('\n')
+}
+
+fn sanitize_name(name: &str) -> Option<String> {
+    let cleaned: String = name.trim().chars().filter(|&c| c != '\r' && c != '\n').collect();
+    if cleaned.is_empty() || BLOCKED_REQUEST_HEADERS.contains(cleaned.to_lowercase().as_str()) {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+fn sanitize_value(value: &str) -> Option<String> {
+    let cleaned: String = value.trim().chars().filter(|&c| c != '\r' && c != '\n').collect();
+    if cleaned.is_empty() { None } else { Some(cleaned) }
+}
+
+fn check_cookie_security(cookie: &str) -> (bool, Option<String>) {
+    let lower = cookie.to_lowercase();
+    let parts: Vec<&str> = lower.split(';').collect();
+    let has_secure = parts.iter().any(|p| p.trim() == "secure");
+    let has_samesite = parts.iter().any(|p| p.trim().starts_with("samesite"));
+    if has_samesite {
+        for part in &parts {
+            if part.contains("samesite=none") && !has_secure {
+                return (
+                    false,
+                    Some("Cookie with SameSite=None without Secure flag".to_string()),
+                );
+            }
+        }
+    }
+    (true, None)
+}
+
+/// Remove CRLF injection and blocked headers from request headers dict.
+#[pyfunction]
+pub fn sanitize_request_headers(headers: HashMap<String, String>) -> HashMap<String, String> {
+    headers
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let k = sanitize_name(&key)?;
+            let v = sanitize_value(&value)?;
+            Some((k, v))
+        })
+        .collect()
+}
+
+/// Check response headers for dangerous headers, CRLF, and cookie security.
+/// Returns (ok: bool, error: str | None).
+#[pyfunction]
+pub fn check_response_headers(headers: HashMap<String, String>) -> (bool, Option<String>) {
+    for (key, value) in &headers {
+        let key_lower = key.to_lowercase();
+        if DANGEROUS_RESPONSE_HEADERS.contains(key_lower.as_str()) {
+            return (false, Some(format!("Dangerous header detected: {}", key)));
+        }
+        if has_crlf(value) {
+            return (false, Some(format!("CRLF injection detected in header: {}", key)));
+        }
+        if key_lower == "set-cookie" {
+            let check = check_cookie_security(value);
+            if !check.0 {
+                return check;
+            }
+        }
+    }
+    (true, None)
+}

--- a/fasthttp/_core/src/ip.rs
+++ b/fasthttp/_core/src/ip.rs
@@ -1,0 +1,95 @@
+use once_cell::sync::Lazy;
+use pyo3::prelude::*;
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv6Addr};
+
+struct Ipv4Network {
+    addr: u32,
+    mask: u32,
+}
+
+impl Ipv4Network {
+    const fn new(a: u8, b: u8, c: u8, d: u8, prefix: u8) -> Self {
+        let addr = u32::from_be_bytes([a, b, c, d]);
+        let mask = if prefix == 0 { 0 } else { !0u32 << (32 - prefix as u32) };
+        Self { addr: addr & mask, mask }
+    }
+
+    #[inline]
+    fn contains(&self, ip: u32) -> bool {
+        (ip & self.mask) == self.addr
+    }
+}
+
+// Full private range table — union of ssrf.py + redirect.py lists.
+const PRIVATE_IPV4_NETS: &[Ipv4Network] = &[
+    Ipv4Network::new(10, 0, 0, 0, 8),        // 10.0.0.0/8       RFC1918
+    Ipv4Network::new(172, 16, 0, 0, 12),      // 172.16.0.0/12    RFC1918
+    Ipv4Network::new(192, 168, 0, 0, 16),     // 192.168.0.0/16   RFC1918
+    Ipv4Network::new(127, 0, 0, 0, 8),        // 127.0.0.0/8      loopback
+    Ipv4Network::new(169, 254, 0, 0, 16),     // 169.254.0.0/16   link-local
+    Ipv4Network::new(0, 0, 0, 0, 8),          // 0.0.0.0/8
+    Ipv4Network::new(100, 64, 0, 0, 10),      // 100.64.0.0/10    shared (RFC6598)
+    Ipv4Network::new(192, 0, 0, 0, 24),       // 192.0.0.0/24     IETF protocol
+    Ipv4Network::new(192, 0, 2, 0, 24),       // 192.0.2.0/24     TEST-NET-1
+    Ipv4Network::new(198, 51, 100, 0, 24),    // 198.51.100.0/24  TEST-NET-2
+    Ipv4Network::new(203, 0, 113, 0, 24),     // 203.0.113.0/24   TEST-NET-3
+    Ipv4Network::new(224, 0, 0, 0, 4),        // 224.0.0.0/4      multicast
+    Ipv4Network::new(240, 0, 0, 0, 4),        // 240.0.0.0/4      reserved
+];
+
+#[inline]
+fn is_ipv6_link_local(ip: &Ipv6Addr) -> bool {
+    let b = ip.octets();
+    b[0] == 0xfe && (b[1] & 0xc0) == 0x80
+}
+
+/// Return True if ip_str is private/loopback/link-local/multicast/reserved.
+/// Accepts IPv4 and IPv6. Returns False for invalid input.
+#[pyfunction]
+pub fn is_private_ip(ip_str: &str) -> bool {
+    match ip_str.trim().parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) => {
+            let n = u32::from(v4);
+            PRIVATE_IPV4_NETS.iter().any(|net| net.contains(n))
+        }
+        Ok(IpAddr::V6(v6)) => {
+            v6.is_loopback() || v6.is_multicast() || is_ipv6_link_local(&v6)
+        }
+        Err(_) => false,
+    }
+}
+
+static LOCAL_HOSTNAME_EXACT: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    HashSet::from([
+        "localho.st",
+        "lvh.me",
+        "0x7f000001",
+        "127.1",
+        "::1",
+        "0:0:0:0:0:0:0:1",
+        "127.0.0.1",
+        "0.0.0.0",
+        "0",
+    ])
+});
+
+// Checked with ends_with — matches Python's exact behaviour.
+const LOCAL_DOMAIN_SUFFIXES: &[&str] = &[
+    "localhost",
+    "localhost.localdomain",
+    "local",
+    "intranet",
+    "internal",
+    "private",
+];
+
+/// Return True if hostname should be treated as local/internal without DNS lookup.
+#[pyfunction]
+pub fn is_local_hostname(hostname: &str) -> bool {
+    let lower = hostname.trim().to_lowercase();
+    if LOCAL_HOSTNAME_EXACT.contains(lower.as_str()) {
+        return true;
+    }
+    LOCAL_DOMAIN_SUFFIXES.iter().any(|d| lower.ends_with(d))
+}

--- a/fasthttp/_core/src/lib.rs
+++ b/fasthttp/_core/src/lib.rs
@@ -1,151 +1,15 @@
-use md5;
-use once_cell::sync::Lazy;
-use pyo3::exceptions::PyValueError;
+mod headers;
+mod ip;
+mod secrets;
+mod url_utils;
+mod xss;
+
+use headers::{check_response_headers, sanitize_request_headers};
+use ip::{is_local_hostname, is_private_ip};
 use pyo3::prelude::*;
-use regex::Regex;
-use std::collections::HashMap;
-use url::Url;
-
-static CSS_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)<link[^>]+rel=["']stylesheet["'][^>]+href=["']([^"']+)["']"#).unwrap()
-});
-
-static JS_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)<script[^>]+src=["']([^"']+)["']"#).unwrap()
-});
-
-fn urljoin_impl(base: &str, path: &str) -> String {
-    match Url::parse(base) {
-        Ok(base_url) => match base_url.join(path) {
-            Ok(joined) => joined.to_string(),
-            Err(_) => path.to_string(),
-        },
-        Err(_) => path.to_string(),
-    }
-}
-
-/// Ensure URL has an explicit https:// or http:// scheme.
-#[pyfunction]
-fn check_https_url(url: &str) -> String {
-    let url = url.trim();
-    if url.starts_with("https://") || url.starts_with("http://") {
-        return url.to_string();
-    }
-    format!("https://{url}")
-}
-
-/// Join a path prefix with a URL fragment, normalising slashes.
-#[pyfunction]
-fn join_prefix(prefix: &str, url: &str) -> String {
-    let mut prefix = prefix.trim().to_string();
-    let mut url = url.trim().to_string();
-
-    if prefix.is_empty() {
-        return url;
-    }
-
-    if !prefix.starts_with('/') {
-        prefix = format!("/{prefix}");
-    }
-    if prefix != "/" && prefix.ends_with('/') {
-        prefix.pop();
-    }
-
-    if !url.starts_with('/') {
-        url = format!("/{url}");
-    }
-
-    if url == "/" {
-        return if prefix.is_empty() {
-            "/".to_string()
-        } else {
-            prefix
-        };
-    }
-
-    format!("{prefix}{url}")
-}
-
-/// Resolve a route URL against an optional base_url and prefix.
-///
-/// Rules:
-/// - Absolute URLs (http/https) are returned unchanged.
-/// - Relative paths require base_url; raises ValueError if missing.
-/// - Without base_url, bare hostnames get https:// prepended.
-#[pyfunction]
-fn resolve_url(url: &str, base_url: Option<&str>, prefix: &str) -> PyResult<String> {
-    let url = url.trim();
-
-    if url.starts_with("https://") || url.starts_with("http://") {
-        return Ok(url.to_string());
-    }
-
-    let Some(base) = base_url else {
-        if url.starts_with('/') {
-            return Err(PyValueError::new_err(format!(
-                "Relative URL requires base_url. Got url={url:?} without base_url."
-            )));
-        }
-        return Ok(check_https_url(url));
-    };
-
-    let base = check_https_url(base);
-    let base_with_slash = format!("{}/", base.trim_end_matches('/'));
-    let joined = join_prefix(prefix, url);
-    let path = joined.trim_start_matches('/');
-
-    Ok(urljoin_impl(&base_with_slash, path))
-}
-
-/// Resolve a URL against an optional base URL (no prefix logic).
-#[pyfunction]
-fn apply_base_url(url: &str, base_url: Option<&str>) -> String {
-    let url = url.trim();
-
-    if url.starts_with("https://") || url.starts_with("http://") {
-        return url.to_string();
-    }
-
-    match base_url {
-        Some(base) if !base.is_empty() => check_https_url(&format!(
-            "{}/{}",
-            base.trim_end_matches('/'),
-            url.trim_start_matches('/')
-        )),
-        _ => check_https_url(url),
-    }
-}
-
-/// Extract CSS and JS asset URLs from an HTML string.
-///
-/// Returns a dict with keys "css" and "js", each a list of resolved URLs.
-#[pyfunction]
-fn extract_assets(html: &str, base_url: &str) -> HashMap<String, Vec<String>> {
-    let css: Vec<String> = CSS_RE
-        .captures_iter(html)
-        .filter_map(|cap| cap.get(1))
-        .map(|m| urljoin_impl(base_url, m.as_str()))
-        .collect();
-
-    let js: Vec<String> = JS_RE
-        .captures_iter(html)
-        .filter_map(|cap| cap.get(1))
-        .map(|m| urljoin_impl(base_url, m.as_str()))
-        .collect();
-
-    HashMap::from([("css".to_string(), css), ("js".to_string(), js)])
-}
-
-/// Generate a cache key: MD5( "METHOD:url:sorted_params_json" ).
-///
-/// `params_json` must be a JSON string with keys already sorted (use
-/// `orjson.dumps(params, option=orjson.OPT_SORT_KEYS).decode()` on the
-/// Python side).
-#[pyfunction]
-fn cache_key(method: &str, url: &str, params_json: &str) -> String {
-    let raw = format!("{method}:{url}:{params_json}");
-    format!("{:x}", md5::compute(raw.as_bytes()))
-}
+use secrets::{mask_cookie, mask_headers, mask_log_message, should_mask_value};
+use url_utils::{apply_base_url, cache_key, check_https_url, extract_assets, join_prefix, resolve_url};
+use xss::{detect_xss, sanitize_html};
 
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -155,5 +19,15 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(apply_base_url, m)?)?;
     m.add_function(wrap_pyfunction!(extract_assets, m)?)?;
     m.add_function(wrap_pyfunction!(cache_key, m)?)?;
+    m.add_function(wrap_pyfunction!(mask_cookie, m)?)?;
+    m.add_function(wrap_pyfunction!(mask_headers, m)?)?;
+    m.add_function(wrap_pyfunction!(mask_log_message, m)?)?;
+    m.add_function(wrap_pyfunction!(should_mask_value, m)?)?;
+    m.add_function(wrap_pyfunction!(detect_xss, m)?)?;
+    m.add_function(wrap_pyfunction!(sanitize_html, m)?)?;
+    m.add_function(wrap_pyfunction!(sanitize_request_headers, m)?)?;
+    m.add_function(wrap_pyfunction!(check_response_headers, m)?)?;
+    m.add_function(wrap_pyfunction!(is_private_ip, m)?)?;
+    m.add_function(wrap_pyfunction!(is_local_hostname, m)?)?;
     Ok(())
 }

--- a/fasthttp/_core/src/secrets.rs
+++ b/fasthttp/_core/src/secrets.rs
@@ -1,0 +1,101 @@
+use once_cell::sync::Lazy;
+use pyo3::prelude::*;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+
+static SECRET_HEADERS_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    HashSet::from([
+        "authorization",
+        "x-api-key",
+        "x-auth-token",
+        "x-access-token",
+        "cookie",
+        "set-cookie",
+        "proxy-authorization",
+        "www-authenticate",
+    ])
+});
+
+static SECRET_PARAM_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)api[_-]?key|token|password|secret|auth|bearer|credential|private[_-]?key|access[_-]?key|session[_-]?id",
+    )
+    .unwrap()
+});
+
+static MASK_BEARER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(Bearer\s+)[a-zA-Z0-9\-_.~+/]+=*").unwrap());
+static MASK_BASIC_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(Basic\s+)[a-zA-Z0-9+/]+=*").unwrap());
+static MASK_TOKEN_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(token[=:]\s*)[^\s&]+").unwrap());
+static MASK_APIKEY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(api[_-]?key[=:]\s*)[^\s&]+").unwrap());
+static MASK_PASSWORD_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(password[=:]\s*)[^\s&]+").unwrap());
+static MASK_SECRET_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)(secret[=:]\s*)[^\s&]+").unwrap());
+
+const COOKIE_SENSITIVE: &[&str] = &["session", "token", "id", "key", "auth"];
+
+/// Mask sensitive cookie name=value pairs, leaving non-sensitive ones unchanged.
+#[pyfunction]
+pub fn mask_cookie(cookie: &str) -> String {
+    let parts: Vec<&str> = cookie.split(';').collect();
+    let masked: Vec<String> = parts
+        .iter()
+        .map(|part| {
+            if let Some(eq_pos) = part.find('=') {
+                let name = part[..eq_pos].trim();
+                let name_lower = name.to_lowercase();
+                if COOKIE_SENSITIVE.iter().any(|p| name_lower.contains(p)) {
+                    format!("{}=*****", name)
+                } else {
+                    part.to_string()
+                }
+            } else {
+                part.to_string()
+            }
+        })
+        .collect();
+    masked.join("; ")
+}
+
+/// Mask secret HTTP headers (Authorization, Cookie, etc.) for safe logging.
+#[pyfunction]
+pub fn mask_headers(headers: HashMap<String, String>) -> HashMap<String, String> {
+    headers
+        .into_iter()
+        .map(|(key, value)| {
+            let key_lower = key.to_lowercase();
+            let masked = if SECRET_HEADERS_SET.contains(key_lower.as_str()) {
+                if key_lower == "cookie" || key_lower == "set-cookie" {
+                    mask_cookie(&value)
+                } else {
+                    "*****".to_string()
+                }
+            } else {
+                value
+            };
+            (key, masked)
+        })
+        .collect()
+}
+
+/// Apply regex-based secret masking to a log message string.
+#[pyfunction]
+pub fn mask_log_message(message: &str) -> String {
+    let r = MASK_BEARER_RE.replace_all(message, "${1}*****");
+    let r = MASK_BASIC_RE.replace_all(r.as_ref(), "${1}*****");
+    let r = MASK_TOKEN_RE.replace_all(r.as_ref(), "${1}*****");
+    let r = MASK_APIKEY_RE.replace_all(r.as_ref(), "${1}*****");
+    let r = MASK_PASSWORD_RE.replace_all(r.as_ref(), "${1}*****");
+    let r = MASK_SECRET_RE.replace_all(r.as_ref(), "${1}*****");
+    r.into_owned()
+}
+
+/// Return True if the key name matches known secret parameter patterns.
+#[pyfunction]
+pub fn should_mask_value(key: &str) -> bool {
+    SECRET_PARAM_RE.is_match(key)
+}

--- a/fasthttp/_core/src/url_utils.rs
+++ b/fasthttp/_core/src/url_utils.rs
@@ -1,0 +1,137 @@
+use md5;
+use once_cell::sync::Lazy;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use regex::Regex;
+use url::Url;
+use std::collections::HashMap;
+
+static CSS_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)<link[^>]+rel=["']stylesheet["'][^>]+href=["']([^"']+)["']"#).unwrap()
+});
+
+static JS_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)<script[^>]+src=["']([^"']+)["']"#).unwrap()
+});
+
+pub(crate) fn urljoin(base: &str, path: &str) -> String {
+    match Url::parse(base) {
+        Ok(base_url) => match base_url.join(path) {
+            Ok(joined) => joined.to_string(),
+            Err(_) => path.to_string(),
+        },
+        Err(_) => path.to_string(),
+    }
+}
+
+/// Ensure URL has an explicit https:// or http:// scheme.
+#[pyfunction]
+pub fn check_https_url(url: &str) -> String {
+    let url = url.trim();
+    if url.starts_with("https://") || url.starts_with("http://") {
+        return url.to_string();
+    }
+    format!("https://{url}")
+}
+
+/// Join a path prefix with a URL fragment, normalising slashes.
+#[pyfunction]
+pub fn join_prefix(prefix: &str, url: &str) -> String {
+    let mut prefix = prefix.trim().to_string();
+    let mut url = url.trim().to_string();
+
+    if prefix.is_empty() {
+        return url;
+    }
+
+    if !prefix.starts_with('/') {
+        prefix = format!("/{prefix}");
+    }
+    if prefix != "/" && prefix.ends_with('/') {
+        prefix.pop();
+    }
+
+    if !url.starts_with('/') {
+        url = format!("/{url}");
+    }
+
+    if url == "/" {
+        return if prefix.is_empty() {
+            "/".to_string()
+        } else {
+            prefix
+        };
+    }
+
+    format!("{prefix}{url}")
+}
+
+/// Resolve a route URL against an optional base_url and prefix.
+#[pyfunction]
+pub fn resolve_url(url: &str, base_url: Option<&str>, prefix: &str) -> PyResult<String> {
+    let url = url.trim();
+
+    if url.starts_with("https://") || url.starts_with("http://") {
+        return Ok(url.to_string());
+    }
+
+    let Some(base) = base_url else {
+        if url.starts_with('/') {
+            return Err(PyValueError::new_err(format!(
+                "Relative URL requires base_url. Got url={url:?} without base_url."
+            )));
+        }
+        return Ok(check_https_url(url));
+    };
+
+    let base = check_https_url(base);
+    let base_with_slash = format!("{}/", base.trim_end_matches('/'));
+    let joined = join_prefix(prefix, url);
+    let path = joined.trim_start_matches('/');
+
+    Ok(urljoin(&base_with_slash, path))
+}
+
+/// Resolve a URL against an optional base URL (no prefix logic).
+#[pyfunction]
+pub fn apply_base_url(url: &str, base_url: Option<&str>) -> String {
+    let url = url.trim();
+
+    if url.starts_with("https://") || url.starts_with("http://") {
+        return url.to_string();
+    }
+
+    match base_url {
+        Some(base) if !base.is_empty() => check_https_url(&format!(
+            "{}/{}",
+            base.trim_end_matches('/'),
+            url.trim_start_matches('/')
+        )),
+        _ => check_https_url(url),
+    }
+}
+
+/// Extract CSS and JS asset URLs from an HTML string.
+#[pyfunction]
+pub fn extract_assets(html: &str, base_url: &str) -> HashMap<String, Vec<String>> {
+    let css: Vec<String> = CSS_RE
+        .captures_iter(html)
+        .filter_map(|cap| cap.get(1))
+        .map(|m| urljoin(base_url, m.as_str()))
+        .collect();
+
+    let js: Vec<String> = JS_RE
+        .captures_iter(html)
+        .filter_map(|cap| cap.get(1))
+        .map(|m| urljoin(base_url, m.as_str()))
+        .collect();
+
+    HashMap::from([("css".to_string(), css), ("js".to_string(), js)])
+}
+
+/// Generate a cache key: MD5( "METHOD:url:sorted_params_json" ).
+#[pyfunction]
+pub fn cache_key(method: &str, url: &str, params_json: &str) -> String {
+    let raw = format!("{method}:{url}:{params_json}");
+    format!("{:x}", md5::compute(raw.as_bytes()))
+}

--- a/fasthttp/_core/src/xss.rs
+++ b/fasthttp/_core/src/xss.rs
@@ -1,0 +1,60 @@
+use once_cell::sync::Lazy;
+use pyo3::prelude::*;
+use regex::Regex;
+
+static XSS_SCRIPT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)<script[^>]*>").unwrap());
+static XSS_JS_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)javascript:").unwrap());
+static XSS_ONHANDLER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)on\w+\s*=").unwrap());
+static XSS_IFRAME_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)<iframe[^>]*>").unwrap());
+static XSS_OBJECT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)<object[^>]*>").unwrap());
+static XSS_EMBED_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)<embed[^>]*>").unwrap());
+static XSS_APPLET_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)<applet[^>]*>").unwrap());
+static XSS_VBSCRIPT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)vbscript:").unwrap());
+static XSS_DATA_HTML_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)data:text/html").unwrap());
+static XSS_EVENT_HANDLER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)\s+on\w+\s*=\s*["']"#).unwrap());
+static HTML_TAG_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"<[^>]+>").unwrap());
+static SCRIPT_TAG_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?is)<script[^>]*>.*?</script>").unwrap());
+
+/// Scan content for XSS patterns. Returns (found: bool, reason: str | None).
+#[pyfunction]
+pub fn detect_xss(content: &str) -> (bool, Option<String>) {
+    if XSS_SCRIPT_RE.is_match(content)
+        || XSS_JS_RE.is_match(content)
+        || XSS_ONHANDLER_RE.is_match(content)
+        || XSS_IFRAME_RE.is_match(content)
+        || XSS_OBJECT_RE.is_match(content)
+        || XSS_EMBED_RE.is_match(content)
+        || XSS_APPLET_RE.is_match(content)
+        || XSS_VBSCRIPT_RE.is_match(content)
+        || XSS_DATA_HTML_RE.is_match(content)
+    {
+        return (true, Some("Potential XSS detected in response".to_string()));
+    }
+    if XSS_EVENT_HANDLER_RE.is_match(content) {
+        return (
+            true,
+            Some("Potential XSS (event handler) detected in response".to_string()),
+        );
+    }
+    (false, None)
+}
+
+/// Strip script tags and all HTML tags from content.
+#[pyfunction]
+pub fn sanitize_html(content: &str) -> String {
+    let r = SCRIPT_TAG_RE.replace_all(content, "");
+    let r = HTML_TAG_RE.replace_all(r.as_ref(), "");
+    r.into_owned()
+}

--- a/fasthttp/security/headers.py
+++ b/fasthttp/security/headers.py
@@ -1,5 +1,14 @@
 import re
 
+try:
+    from fasthttp._core import (
+        sanitize_request_headers as _rs_sanitize_request_headers,
+        check_response_headers as _rs_check_response_headers,
+    )
+    _RUST = True
+except ImportError:
+    _RUST = False
+
 DANGEROUS_RESPONSE_HEADERS = [
     "x-accel-redirect",
     "x-sendfile",
@@ -40,6 +49,8 @@ class HeaderProtection:
         self,
         headers: dict[str, str]
     ) -> dict[str, str]:
+        if _RUST:
+            return _rs_sanitize_request_headers(headers)
         sanitized = {}
         for key, value in headers.items():
             key_clean = self._sanitize_header_name(key)
@@ -70,6 +81,8 @@ class HeaderProtection:
         self,
         headers: dict[str, str]
     ) -> tuple[bool, str | None]:
+        if _RUST:
+            return _rs_check_response_headers(headers)
         for key, value in headers.items():
             key_lower = key.lower()
 

--- a/fasthttp/security/redirect.py
+++ b/fasthttp/security/redirect.py
@@ -3,6 +3,12 @@ import socket
 from urllib.parse import urlparse
 from dataclasses import dataclass
 
+try:
+    from fasthttp._core import is_private_ip as _rs_is_private_ip
+    _RUST = True
+except ImportError:
+    _RUST = False
+
 PRIVATE_RANGES = [
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
@@ -77,21 +83,23 @@ class RedirectProtection:
 
         try:
             ip_str = socket.gethostbyname(hostname)
-            ip = ipaddress.ip_address(ip_str)
 
-            if ip.is_loopback:
-                return False, f"Redirect to loopback IP: {ip}"
-
-            if ip.is_link_local:
-                return False, f"Redirect to link-local IP: {ip}"
-
-            for network in PRIVATE_RANGES:
-                if ip in network:
-                    return False, f"Redirect to private IP: {ip} ({network})"
+            if _RUST:
+                if _rs_is_private_ip(ip_str):
+                    return False, f"Redirect to private/internal IP: {ip_str}"
+            else:
+                ip = ipaddress.ip_address(ip_str)
+                if ip.is_loopback:
+                    return False, f"Redirect to loopback IP: {ip}"
+                if ip.is_link_local:
+                    return False, f"Redirect to link-local IP: {ip}"
+                for network in PRIVATE_RANGES:
+                    if ip in network:
+                        return False, f"Redirect to private IP: {ip} ({network})"
 
         except socket.gaierror:
             pass
-        except Exception as e:
+        except Exception:
             pass
 
         return True, None

--- a/fasthttp/security/response.py
+++ b/fasthttp/security/response.py
@@ -1,6 +1,15 @@
 import re
 from dataclasses import dataclass
 
+try:
+    from fasthttp._core import (
+        detect_xss as _rs_detect_xss,
+        sanitize_html as _rs_sanitize_html,
+    )
+    _RUST = True
+except ImportError:
+    _RUST = False
+
 DANGEROUS_CONTENT_TYPES = [
     "text/html",
     "application/xhtml+xml",
@@ -78,23 +87,20 @@ class ResponseProtection:
     def sanitize_html(self, content: str) -> str:
         if not self._config.sanitize_html:
             return content
-
-        result = content
-
-        result = SCRIPT_TAG_PATTERN.sub("", result)
-
+        if _RUST:
+            return _rs_sanitize_html(content)
+        result = SCRIPT_TAG_PATTERN.sub("", content)
         result = HTML_TAG_PATTERN.sub("", result)
-
         return result
 
     def detect_xss(self, content: str) -> tuple[bool, str | None]:
+        if _RUST:
+            return _rs_detect_xss(content)
         for pattern in XSS_PATTERNS:
             if pattern.search(content):
                 return True, "Potential XSS detected in response"
-
         if EVENT_HANDLER_PATTERN.search(content):
             return True, "Potential XSS (event handler) detected in response"
-
         return False, None
 
     def validate_response(

--- a/fasthttp/security/secrets.py
+++ b/fasthttp/security/secrets.py
@@ -1,5 +1,16 @@
 import re
 
+try:
+    from fasthttp._core import (
+        mask_cookie as _rs_mask_cookie,
+        mask_headers as _rs_mask_headers,
+        mask_log_message as _rs_mask_log_message,
+        should_mask_value as _rs_should_mask_value,
+    )
+    _RUST = True
+except ImportError:
+    _RUST = False
+
 SECRET_HEADERS = [
     "authorization",
     "x-api-key",
@@ -39,6 +50,8 @@ class SecretsMasking:
         ]
 
     def mask_headers(self, headers: dict[str, str]) -> dict[str, str]:
+        if _RUST:
+            return _rs_mask_headers(headers)
         masked = {}
         for key, value in headers.items():
             key_lower = key.lower()
@@ -54,6 +67,8 @@ class SecretsMasking:
         return masked
 
     def _mask_cookie(self, cookie: str) -> str:
+        if _RUST:
+            return _rs_mask_cookie(cookie)
         parts = cookie.split(";")
         masked_parts = []
         for part in parts:
@@ -76,10 +91,14 @@ class SecretsMasking:
         return url
 
     def mask_log_message(self, message: str) -> str:
+        if _RUST:
+            return _rs_mask_log_message(message)
         result = message
         for pattern in self._compiled_patterns:
             result = pattern.sub(r"\1*****", result)
         return result
 
     def should_mask_value(self, key: str) -> bool:
+        if _RUST:
+            return _rs_should_mask_value(key)
         return bool(SECRET_PARAM_REGEX.search(key))

--- a/fasthttp/security/ssrf.py
+++ b/fasthttp/security/ssrf.py
@@ -3,6 +3,15 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+try:
+    from fasthttp._core import (
+        is_private_ip as _rs_is_private_ip,
+        is_local_hostname as _rs_is_local_hostname,
+    )
+    _RUST = True
+except ImportError:
+    _RUST = False
+
 PRIVATE_RANGES = [
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
@@ -51,31 +60,30 @@ class SSRFProtection:
 
         hostname_lower = hostname.lower()
 
-        if hostname_lower in LOCALHOST_NAMES:
-            return False
-
-        if any(hostname_lower.endswith(domain) for domain in LOCAL_DOMAINS):
-            return False
-
-        if hostname_lower in ("127.0.0.1", "0.0.0.0", "::1", "0"):
-            return False
+        if _RUST:
+            if _rs_is_local_hostname(hostname_lower):
+                return False
+        else:
+            if hostname_lower in LOCALHOST_NAMES:
+                return False
+            if any(hostname_lower.endswith(domain) for domain in LOCAL_DOMAINS):
+                return False
+            if hostname_lower in ("127.0.0.1", "0.0.0.0", "::1", "0"):
+                return False
 
         try:
             ip_str = await asyncio.to_thread(socket.gethostbyname, hostname)
-            ip = ipaddress.ip_address(ip_str)
 
-            if ip.is_loopback:
-                return False
-
-            if ip.is_link_local:
-                return False
-
-            if ip.is_multicast:
-                return False
-
-            for network in PRIVATE_RANGES:
-                if ip in network:
+            if _RUST:
+                if _rs_is_private_ip(ip_str):
                     return False
+            else:
+                ip = ipaddress.ip_address(ip_str)
+                if ip.is_loopback or ip.is_link_local or ip.is_multicast:
+                    return False
+                for network in PRIVATE_RANGES:
+                    if ip in network:
+                        return False
 
         except socket.gaierror:
             return True


### PR DESCRIPTION
## 🚀 Description

Move security hot-path functions from Python to the Rust `_core` extension and reorganize `lib.rs`
  into modules.

  ## Changes

  - Added 10 new Rust functions: secrets masking, XSS detection, HTML sanitization, header sanitization,
   IP/hostname private range checks
  - Split `lib.rs` into `secrets.rs`, `xss.rs`, `headers.rs`, `ip.rs`, `url_utils.rs`
  - `ssrf.py` and `redirect.py` no longer duplicate private IP range logic — both delegate to a single
  Rust function
  - Python fallback preserved via `try/except ImportError` in all updated modules

  ## Test plan

  - [x] 62 tests pass
  - [x] Smoke-tested all new Rust functions manually