### PR TITLE
Feat/json orjson

### DIFF
--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -1236,6 +1236,7 @@ class ASGIApp:
         self.fasthttp = app
         self.docs_urls = build_docs_urls(base_url)
         self._shared_client: httpx.AsyncClient | None = None
+        self._openapi_cache: bytes | None = None
 
     async def __call__(
         self,
@@ -1297,11 +1298,13 @@ class ASGIApp:
                 ),
             )
         elif path == self.docs_urls["openapi_url"]:
-            schema = generate_openapi_schema(
-                self.fasthttp,
-                server_url=self.docs_urls["request_url"],
-            )
-            await self._send_json(send, schema)
+            if self._openapi_cache is None:
+                schema = generate_openapi_schema(
+                    self.fasthttp,
+                    server_url=self.docs_urls["request_url"],
+                )
+                self._openapi_cache = orjson.dumps(schema, option=orjson.OPT_INDENT_2)
+            await self._send_raw_json(send, self._openapi_cache)
         elif path == self.docs_urls["request_url"]:
             await self._handle_proxy(send, method, body)
         else:
@@ -1323,7 +1326,9 @@ class ASGIApp:
         )
 
     async def _send_json(self, send: Callable[..., Any], data: dict) -> None:
-        json_str = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode()
+        await self._send_raw_json(send, orjson.dumps(data, option=orjson.OPT_INDENT_2))
+
+    async def _send_raw_json(self, send: Callable[..., Any], body: bytes) -> None:
         await send(
             {
                 "type": "http.response.start",
@@ -1334,7 +1339,7 @@ class ASGIApp:
         await send(
             {
                 "type": "http.response.body",
-                "body": json_str.encode("utf-8"),
+                "body": body,
             }
         )
 

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import secrets
 import sys
 import time
@@ -9,6 +8,7 @@ import uuid
 from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
 
 import httpx
+import orjson
 from annotated_doc import Doc
 
 from .client import HTTPClient
@@ -386,7 +386,6 @@ class FastHTTP:
         self.generate_startup_uuid = generate_startup_uuid
         self.startup_uuid_version = startup_uuid_version
 
-
         if middleware is None:
             normalized_middleware: list[BaseMiddleware] | MiddlewareChain = []
         elif isinstance(middleware, (MiddlewareChain, list)):
@@ -430,7 +429,7 @@ class FastHTTP:
             self.logger,
             self.middleware_manager,
             self.security,
-            self.startup_uuid
+            self.startup_uuid,
         )
 
     def _check_annotated_parameters(
@@ -463,7 +462,7 @@ class FastHTTP:
                     ```
                 """
             ),
-        ]
+        ],
     ) -> None:
         check_annotated_parameters(func=func)
 
@@ -497,15 +496,11 @@ class FastHTTP:
                     ```
                 """
             ),
-        ]
+        ],
     ) -> None:
         check_annotated_return(func=func)
 
-    def _check_https_url(
-        self,
-        *,
-        url: str
-    ) -> str:
+    def _check_https_url(self, *, url: str) -> str:
         """
         Ensure URL has a valid scheme (http:// or https://).
 
@@ -914,6 +909,7 @@ class FastHTTP:
                 return {"query": "{ user(id: 1) { name } }"}
         ```
         """
+
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
             validate_handler(func=func)
 
@@ -967,20 +963,13 @@ class FastHTTP:
                     dependencies=dependencies,
                 )
             )
-            self.logger.debug(
-                "Registered GraphQL %s: %s",
-                operation_type,
-                url
-            )
+            self.logger.debug("Registered GraphQL %s: %s", operation_type, url)
             return func
 
         return decorator
 
     def _log_result(
-        self,
-        route: Route,
-        elapsed: float,
-        result: Response | None
+        self, route: Route, elapsed: float, result: Response | None
     ) -> None:
         if result and isinstance(result.status, int):
             self.logger.info(
@@ -1000,8 +989,7 @@ class FastHTTP:
                     if get_origin(route.response_model) is list:
                         item_model = get_args(route.response_model)[0]
                         validated = [
-                            item_model.model_validate(item)
-                            for item in json_data
+                            item_model.model_validate(item) for item in json_data
                         ]
                     else:
                         validated = route.response_model.model_validate(  # type: ignore
@@ -1050,16 +1038,14 @@ class FastHTTP:
                         ]
                     results = [t.result() for t in tg_tasks]
                 else:
-                    results = await asyncio.gather(*[
-                        self._run_route(client, route) for route in routes
-                    ])
+                    results = await asyncio.gather(
+                        *[self._run_route(client, route) for route in routes]
+                    )
 
                 for route, elapsed, result in results:
                     self._log_result(route, elapsed, result)
             else:
-                route, elapsed, result = await self._run_route(
-                    client, routes[0]
-                )
+                route, elapsed, result = await self._run_route(client, routes[0])
                 self._log_result(route, elapsed, result)
 
         total_time = time.perf_counter() - start_all
@@ -1094,12 +1080,10 @@ class FastHTTP:
         routes_to_run = self.routes
         if tags:
             routes_to_run = [
-                route for route in self.routes
-                if any(tag in route.tags for tag in tags)
+                route for route in self.routes if any(tag in route.tags for tag in tags)
             ]
             self.logger.info(
-                "Running %d routes with tags: %s",
-                len(routes_to_run), tags
+                "Running %d routes with tags: %s", len(routes_to_run), tags
             )
 
         if not routes_to_run:
@@ -1176,9 +1160,11 @@ class FastHTTP:
 
             app = FastHTTP()
 
+
             @app.get("https://google.com")
             async def index(resp):
                 return resp.status
+
 
             app.web_run()
             ```
@@ -1191,9 +1177,7 @@ class FastHTTP:
         """
         self.logger.info("FastHTTP started")
 
-        docs_base_url = (
-            base_url if base_url is not None else self.docs_base_url
-        )
+        docs_base_url = base_url if base_url is not None else self.docs_base_url
         app = ASGIApp(self, base_url=docs_base_url)
 
         server_base_url = f"http://{host}:{port}"
@@ -1302,7 +1286,9 @@ class ASGIApp:
                     if not message.get("more_body"):
                         break
 
-        if path == self.docs_urls["docs_url"] or path.startswith(f"{self.docs_urls['docs_url']}/"):
+        if path == self.docs_urls["docs_url"] or path.startswith(
+            f"{self.docs_urls['docs_url']}/"
+        ):
             await self._send_html(
                 send,
                 get_swagger_html(
@@ -1322,46 +1308,59 @@ class ASGIApp:
             await self._send_404(send, path)
 
     async def _send_html(self, send: Callable[..., Any], html: str) -> None:
-        await send({
-            "type": "http.response.start",
-            "status": 200,
-            "headers": [[b"content-type", b"text/html; charset=utf-8"]],
-        })
-        await send({
-            "type": "http.response.body",
-            "body": html.encode("utf-8"),
-        })
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/html; charset=utf-8"]],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": html.encode("utf-8"),
+            }
+        )
 
     async def _send_json(self, send: Callable[..., Any], data: dict) -> None:
-        json_str = json.dumps(data, indent=2, ensure_ascii=False)
-        await send({
-            "type": "http.response.start",
-            "status": 200,
-            "headers": [[b"content-type", b"application/json; charset=utf-8"]],
-        })
-        await send({
-            "type": "http.response.body",
-            "body": json_str.encode("utf-8"),
-        })
+        json_str = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"application/json; charset=utf-8"]],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": json_str.encode("utf-8"),
+            }
+        )
 
     async def _send_404(self, send: Callable[..., Any], _path: str = "/") -> None:
         html = get_not_found_html(
             docs_url=self.docs_urls["docs_url"],
             openapi_url=self.docs_urls["openapi_url"],
         )
-        await send({
-            "type": "http.response.start",
-            "status": 404,
-            "headers": [[b"content-type", b"text/html; charset=utf-8"]],
-        })
-        await send({
-            "type": "http.response.body",
-            "body": html.encode("utf-8"),
-        })
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 404,
+                "headers": [[b"content-type", b"text/html; charset=utf-8"]],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": html.encode("utf-8"),
+            }
+        )
 
     def _normalize_url(self, url: str) -> str:
         """Normalize URL for matching."""
         from urllib.parse import urlparse
+
         parsed = urlparse(url)
         return f"{parsed.netloc}{parsed.path}"
 
@@ -1370,7 +1369,10 @@ class ASGIApp:
         normalized_url = self._normalize_url(url)
         for route in self.fasthttp.routes:
             route_normalized = self._normalize_url(route.url)
-            if route.method.upper() == method.upper() and route_normalized == normalized_url:
+            if (
+                route.method.upper() == method.upper()
+                and route_normalized == normalized_url
+            ):
                 return route
         return None
 
@@ -1384,8 +1386,8 @@ class ASGIApp:
             request_data = {}
             if body:
                 try:
-                    request_data = json.loads(body)
-                except json.JSONDecodeError:
+                    request_data = orjson.loads(body)
+                except orjson.JSONDecodeError:
                     await self._send_json(send, {"error": "Invalid JSON"})
                     return
 
@@ -1430,18 +1432,15 @@ class ASGIApp:
                     if get_origin(route.response_model) is list:
                         item_model = get_args(route.response_model)[0]
                         validated = [
-                            item_model.model_validate(item)
-                            for item in json_data
+                            item_model.model_validate(item) for item in json_data
                         ]
-                        result["json"] = [
-                            item.model_dump() for item in validated
-                        ]
+                        result["json"] = [item.model_dump() for item in validated]
                     else:
                         validated = route.response_model.model_validate(  # type: ignore
                             json_data
                         )
                         result["json"] = validated.model_dump()
-                    result["body"] = json.dumps(result["json"], ensure_ascii=False)
+                    result["body"] = orjson.dumps(result["json"]).decode()
                 else:
                     result["json"] = json_data
             except Exception as e:  # noqa: BLE001

--- a/fasthttp/cli/commands.py
+++ b/fasthttp/cli/commands.py
@@ -1,7 +1,7 @@
-import json
 from typing import Any
 
 import httpx
+import orjson
 import typer
 
 from fasthttp.cli.client import CLIResponse, run_request
@@ -34,24 +34,18 @@ def get_output(resp: CLIResponse, output: str) -> str:
         case "status":
             return str(resp.status)
         case "headers":
-            import json
-
-            return json.dumps(resp.headers, indent=2)
+            return orjson.dumps(resp.headers, option=orjson.OPT_INDENT_2).decode()
         case "json":
             if resp.json_data:
-                import json
-
-                return json.dumps(resp.json_data, indent=2)
+                return orjson.dumps(resp.json_data, option=orjson.OPT_INDENT_2).decode()
             return "(no JSON in response)"
         case "text":
             return resp.text
         case "all":
-            import json
-
             return (
                 f"Status: {resp.status}\n"
                 f"Elapsed: {resp.elapsed_ms:.2f}ms\n"
-                f"Headers:\n{json.dumps(resp.headers, indent=2)}\n"
+                f"Headers:\n{orjson.dumps(resp.headers, option=orjson.OPT_INDENT_2).decode()}\n"
                 f"Body:\n{resp.text[:500]}"
             )
         case _:
@@ -61,105 +55,190 @@ def get_output(resp: CLIResponse, output: str) -> str:
 @app.command()
 def get(
     url: str,
-    output: str = typer.Argument("status", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    output: str = typer.Argument(
+        "status", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
-    _execute_request("GET", url, output, headers, timeout=timeout, debug=debug, proxy=proxy)
+    _execute_request(
+        "GET", url, output, headers, timeout=timeout, debug=debug, proxy=proxy
+    )
 
 
 @app.command()
 def post(
     url: str,
-    output: str = typer.Argument("status", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
+    output: str = typer.Argument(
+        "status", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
     json_body: str | None = typer.Option(None, "-j", "--json", help="JSON body"),
     data: str | None = typer.Option(None, "-d", "--data", help="Form data"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
     json_data: dict[str, Any] | None = None
     if json_body:
         try:
-            json_data = json.loads(json_body)
-        except json.JSONDecodeError as e:
+            json_data = orjson.loads(json_body)
+        except orjson.JSONDecodeError as e:
             formatter.error(f"Invalid JSON: {e}")
             raise typer.Exit(1) from e
 
     _execute_request(
-        "POST",url, output, headers, json_data=json_data, data=data, timeout=timeout, debug=debug, proxy=proxy)
+        "POST",
+        url,
+        output,
+        headers,
+        json_data=json_data,
+        data=data,
+        timeout=timeout,
+        debug=debug,
+        proxy=proxy,
+    )
 
 
 @app.command()
 def put(
     url: str,
-    output: str = typer.Argument("status", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
+    output: str = typer.Argument(
+        "status", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
     json_body: str | None = typer.Option(None, "-j", "--json", help="JSON body"),
     data: str | None = typer.Option(None, "-d", "--data", help="Form data"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
     json_data: dict[str, Any] | None = None
     if json_body:
         try:
-            json_data = json.loads(json_body)
-        except json.JSONDecodeError as e:
+            json_data = orjson.loads(json_body)
+        except orjson.JSONDecodeError as e:
             formatter.error(f"Invalid JSON: {e}")
             raise typer.Exit(1) from e
 
-    _execute_request("PUT", url, output, headers, json_data=json_data, data=data, timeout=timeout, debug=debug, proxy=proxy)
+    _execute_request(
+        "PUT",
+        url,
+        output,
+        headers,
+        json_data=json_data,
+        data=data,
+        timeout=timeout,
+        debug=debug,
+        proxy=proxy,
+    )
 
 
 @app.command()
 def patch(
     url: str,
-    output: str = typer.Argument("status", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
+    output: str = typer.Argument(
+        "status", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
     json_body: str | None = typer.Option(None, "-j", "--json", help="JSON body"),
     data: str | None = typer.Option(None, "-d", "--data", help="Form data"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
     json_data: dict[str, Any] | None = None
     if json_body:
         try:
-            json_data = json.loads(json_body)
-        except json.JSONDecodeError as e:
+            json_data = orjson.loads(json_body)
+        except orjson.JSONDecodeError as e:
             formatter.error(f"Invalid JSON: {e}")
             raise typer.Exit(1) from e
 
-    _execute_request("PATCH", url, output, headers, json_data=json_data, data=data, timeout=timeout, debug=debug, proxy=proxy)
+    _execute_request(
+        "PATCH",
+        url,
+        output,
+        headers,
+        json_data=json_data,
+        data=data,
+        timeout=timeout,
+        debug=debug,
+        proxy=proxy,
+    )
 
 
 @app.command()
 def delete(
     url: str,
-    output: str = typer.Argument("status", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    output: str = typer.Argument(
+        "status", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
-    _execute_request("DELETE", url, output, headers, timeout=timeout, debug=debug, proxy=proxy)
+    _execute_request(
+        "DELETE", url, output, headers, timeout=timeout, debug=debug, proxy=proxy
+    )
 
 
 @app.command()
 def graphql(  # noqa: C901
     url: str,
     query: str = typer.Option(..., "-q", "--query", help="GraphQL query (required)"),
-    variables: str | None = typer.Option(None, "-v", "--variables", help="GraphQL variables as JSON"),
-    operation_type: str = typer.Option("query", "-o", "--operation", help="Operation type: query or mutation"),
-    output: str = typer.Argument("json", help="Output: status, headers, json, text, all"),
-    headers: str | None = typer.Option(None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"),
-    timeout: float = typer.Option(30.0, "-t", "--timeout", help="Request timeout in seconds"),
+    variables: str | None = typer.Option(
+        None, "-v", "--variables", help="GraphQL variables as JSON"
+    ),
+    operation_type: str = typer.Option(
+        "query", "-o", "--operation", help="Operation type: query or mutation"
+    ),
+    output: str = typer.Argument(
+        "json", help="Output: status, headers, json, text, all"
+    ),
+    headers: str | None = typer.Option(
+        None, "-H", "--header", help="Headers (Key:Value,Key2:Value2)"
+    ),
+    timeout: float = typer.Option(
+        30.0, "-t", "--timeout", help="Request timeout in seconds"
+    ),
     debug: bool = typer.Option(default=False, help="Enable debug output"),  # noqa: FBT001
-    proxy: str | None = typer.Option(None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"),
+    proxy: str | None = typer.Option(
+        None, "-p", "--proxy", help="Proxy URL (http://, https://, socks5://)"
+    ),
 ) -> None:
     url = _check_https_url(url)
     parsed_headers = parse_headers(headers_str=headers)
@@ -167,15 +246,17 @@ def graphql(  # noqa: C901
     json_data: dict[str, Any] = {"query": query}
     if variables:
         try:
-            json_data["variables"] = json.loads(variables)
-        except json.JSONDecodeError as e:
+            json_data["variables"] = orjson.loads(variables)
+        except orjson.JSONDecodeError as e:
             formatter.error(f"Invalid JSON in variables: {e}")
             raise typer.Exit(1) from e
 
     if debug:
         formatter.info(f"→ GraphQL {operation_type} {url}")
         if parsed_headers:
-            formatter.info(f"  Headers: {json.dumps(parsed_headers, indent=2)}")
+            formatter.info(
+                f"  Headers: {orjson.dumps(parsed_headers, option=orjson.OPT_INDENT_2).decode()}"
+            )
         formatter.info(f"  Query: {query}")
         if variables:
             formatter.info(f"  Variables: {variables}")
@@ -236,9 +317,13 @@ def _execute_request(
     if debug:
         formatter.info(f"→ {method} {url}")
         if headers:
-            formatter.info(f"  Headers: {json.dumps(headers, indent=2)}")
+            formatter.info(
+                f"  Headers: {orjson.dumps(headers, option=orjson.OPT_INDENT_2).decode()}"
+            )
         if json_data:
-            formatter.info(f"  JSON: {json.dumps(json_data, indent=2)}")
+            formatter.info(
+                f"  JSON: {orjson.dumps(json_data, option=orjson.OPT_INDENT_2).decode()}"
+            )
         if data:
             formatter.info(f"  Data: {data}")
         if proxy:

--- a/fasthttp/cli/output.py
+++ b/fasthttp/cli/output.py
@@ -1,6 +1,7 @@
-import json
 import sys
 from typing import Any
+
+import orjson
 
 
 class CLIFormatter:
@@ -42,7 +43,7 @@ class CLIFormatter:
         print(f"{prefix}{self.GRAY}{key}:{self.RESET} {value}")
 
     def json_output(self, data: Any) -> None:  # noqa: ANN401
-        formatted = json.dumps(data, indent=2, ensure_ascii=False)
+        formatted = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode()
         print(f"{self.PURPLE}{formatted}{self.RESET}")
 
 

--- a/fasthttp/cli/repl.py
+++ b/fasthttp/cli/repl.py
@@ -1,13 +1,14 @@
 import asyncio
 import contextlib
-import json
 import shlex
 from typing import Any, ClassVar
 
 import httpx
+import orjson
 
 try:
     import readline  # noqa: F401
+
     READLINE_AVAILABLE = True
 except ImportError:
     READLINE_AVAILABLE = False
@@ -15,6 +16,7 @@ except ImportError:
 
 class Colors:
     """ANSI color codes for terminal output."""
+
     RESET = "\033[0m"
     BOLD = "\033[1m"
     DIM = "\033[2m"
@@ -79,7 +81,9 @@ class FastHTTPRepl:
 
     def print_banner(self) -> None:
         """Print welcome message."""
-        print(f"{Colors.BRIGHT_CYAN}FastHTTP Interactive{Colors.RESET} - {Colors.DIM}Type help for commands{Colors.RESET}")
+        print(
+            f"{Colors.BRIGHT_CYAN}FastHTTP Interactive{Colors.RESET} - {Colors.DIM}Type help for commands{Colors.RESET}"
+        )
         print()
 
     def get_method_color(self, method: str) -> str:
@@ -166,8 +170,8 @@ class FastHTTPRepl:
                 i += 2
             elif arg in ("-j", "--json") and i + 1 < len(args):
                 try:
-                    result["json"] = json.loads(args[i + 1])
-                except json.JSONDecodeError:
+                    result["json"] = orjson.loads(args[i + 1])
+                except orjson.JSONDecodeError:
                     print(f"{Colors.RED}Invalid JSON: {args[i + 1]}{Colors.RESET}")
                 i += 2
             elif arg in ("-d", "--data") and i + 1 < len(args):
@@ -214,10 +218,14 @@ class FastHTTPRepl:
             case "status":
                 return str(resp.status_code)
             case "headers":
-                return json.dumps(dict(resp.headers), indent=2, ensure_ascii=False)
+                return orjson.dumps(
+                    dict(resp.headers), option=orjson.OPT_INDENT_2
+                ).decode()
             case "json":
                 try:
-                    return json.dumps(resp.json(), indent=2, ensure_ascii=False)
+                    return orjson.dumps(
+                        resp.json(), option=orjson.OPT_INDENT_2
+                    ).decode()
                 except Exception:  # noqa: BLE001
                     return resp.text
             case "text":
@@ -226,23 +234,31 @@ class FastHTTPRepl:
                 return f"""{header}
 
 {Colors.BRIGHT_WHITE}Headers:{Colors.RESET}
-{json.dumps(dict(resp.headers), indent=2, ensure_ascii=False)}
+{orjson.dumps(dict(resp.headers), option=orjson.OPT_INDENT_2).decode()}
 
 {Colors.BRIGHT_WHITE}Body:{Colors.RESET}
 {resp.text[:1000]}"""
             case _:
                 try:
-                    return json.dumps(resp.json(), indent=2, ensure_ascii=False)
+                    return orjson.dumps(
+                        resp.json(), option=orjson.OPT_INDENT_2
+                    ).decode()
                 except Exception:  # noqa: BLE001
                     return resp.text
 
-    async def execute_request(self, method: str, url: str, **kwargs: Any,  # noqa: ANN401
+    async def execute_request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,  # noqa: ANN401
     ) -> httpx.Response | None:
         """Execute HTTP request."""
         proxy = kwargs.get("proxy", self.proxy)
 
         try:
-            async with httpx.AsyncClient(proxy=proxy, timeout=kwargs.get("timeout", 30.0)) as client:
+            async with httpx.AsyncClient(
+                proxy=proxy, timeout=kwargs.get("timeout", 30.0)
+            ) as client:
                 return await client.request(
                     method=method,
                     url=url,
@@ -278,7 +294,11 @@ class FastHTTPRepl:
 
         if method == "last":
             if self.last_response:
-                print(json.dumps(self.last_response, indent=2, ensure_ascii=False))
+                print(
+                    orjson.dumps(
+                        self.last_response, option=orjson.OPT_INDENT_2
+                    ).decode()
+                )
             else:
                 print(f"{Colors.DIM}No previous response{Colors.RESET}")
             return
@@ -326,7 +346,9 @@ class FastHTTPRepl:
         if kwargs["headers"]:
             print(f"  {Colors.DIM}Headers: {kwargs['headers']}{Colors.RESET}")
         if kwargs["json"]:
-            print(f"  {Colors.DIM}JSON: {json.dumps(kwargs['json'], ensure_ascii=False)[:100]}{Colors.RESET}")
+            print(
+                f"  {Colors.DIM}JSON: {orjson.dumps(kwargs['json']).decode()[:100]}{Colors.RESET}"
+            )
         if kwargs.get("proxy"):
             print(f"  {Colors.DIM}Proxy: {kwargs['proxy']}{Colors.RESET}")
 
@@ -358,7 +380,9 @@ class FastHTTPRepl:
                 await self.run_command(line)
 
             except KeyboardInterrupt:
-                print(f"\n{Colors.BRIGHT_YELLOW}Use 'exit' or 'q' to quit{Colors.RESET}")
+                print(
+                    f"\n{Colors.BRIGHT_YELLOW}Use 'exit' or 'q' to quit{Colors.RESET}"
+                )
             except EOFError:
                 print(f"\n{Colors.BRIGHT_YELLOW}Goodbye!{Colors.RESET}")
                 break

--- a/fasthttp/openapi/routes.py
+++ b/fasthttp/openapi/routes.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import contextlib
-import json
 from typing import TYPE_CHECKING, Annotated, Any
 
 import httpx
+import orjson
 from annotated_doc import Doc
 
 from fasthttp import status
@@ -64,7 +64,7 @@ async def handle_openapi_json(
     """
     urls = build_docs_urls(base_url)
     schema = generate_openapi_schema(app, server_url=urls["request_url"])
-    json_str = json.dumps(schema, indent=2, ensure_ascii=False)
+    json_str = orjson.dumps(schema, option=orjson.OPT_INDENT_2).decode()
     return Response(
         status=status.HTTP_200_OK,
         text=json_str,
@@ -104,7 +104,7 @@ async def handle_request(
     request_data: Annotated[
         dict[str, Any],
         Doc("Request data from Swagger UI"),
-    ]
+    ],
 ) -> Response:
     """
     Execute HTTP request and return results for Swagger UI.
@@ -130,7 +130,7 @@ async def handle_request(
     if not url:
         return Response(
             status=status.HTTP_400_BAD_REQUEST,
-            text=json.dumps({"error": "URL is required"}),
+            text=orjson.dumps({"error": "URL is required"}).decode(),
             headers={"Content-Type": "application/json"},
         )
 
@@ -161,25 +161,25 @@ async def handle_request(
 
             return Response(
                 status=status.HTTP_200_OK,
-                text=json.dumps(result, indent=2, ensure_ascii=False),
+                text=orjson.dumps(result, option=orjson.OPT_INDENT_2).decode(),
                 headers={"Content-Type": "application/json"},
             )
 
     except httpx.ConnectError as e:
         return Response(
             status=status.HTTP_502_BAD_GATEWAY,
-            text=json.dumps({"error": f"Connection error: {e!s}"}),
+            text=orjson.dumps({"error": f"Connection error: {e!s}"}).decode(),
             headers={"Content-Type": "application/json"},
         )
     except httpx.TimeoutException as e:
         return Response(
             status=status.HTTP_504_GATEWAY_TIMEOUT,
-            text=json.dumps({"error": f"Timeout: {e!s}"}),
+            text=orjson.dumps({"error": f"Timeout: {e!s}"}).decode(),
             headers={"Content-Type": "application/json"},
         )
     except Exception as e:  # noqa: BLE001
         return Response(
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            text=json.dumps({"error": f"Request failed: {e!s}"}),
+            text=orjson.dumps({"error": f"Request failed: {e!s}"}).decode(),
             headers={"Content-Type": "application/json"},
         )

--- a/fasthttp/response.py
+++ b/fasthttp/response.py
@@ -36,6 +36,19 @@ class Response:
     Used by FastHTTP to pass response data to route handlers.
     """
 
+    __slots__ = (
+        "_handler_result",
+        "_method",
+        "_query",
+        "_req_data",
+        "_req_headers",
+        "_req_json",
+        "_url",
+        "headers",
+        "status",
+        "text",
+    )
+
     def __init__(
         self,
         status: Annotated[
@@ -275,12 +288,7 @@ class Response:
             return str(self._req_data)
         return None
 
-    def assets(
-        self,
-        *,
-        css: bool = True,
-        js: bool = True
-    ) -> dict[str, list[str]]:
+    def assets(self, *, css: bool = True, js: bool = True) -> dict[str, list[str]]:
         base_url = self._url if self._url else ""
         result = extract_assets(self.text, base_url)
         if not css:

--- a/fasthttp/routing.py
+++ b/fasthttp/routing.py
@@ -26,6 +26,21 @@ class Route:
     responses in a structured and predictable way.
     """
 
+    __slots__ = (
+        "data",
+        "dependencies",
+        "handler",
+        "json",
+        "method",
+        "params",
+        "request_model",
+        "response_model",
+        "responses",
+        "skip_request",
+        "tags",
+        "url",
+    )
+
     def __init__(
         self,
         *,
@@ -415,6 +430,7 @@ class Router:
         This stores the route in an unresolved form until `build_routes()`
         is called.
         """
+
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
             validate_handler(func=func)
 
@@ -843,9 +859,7 @@ class Router:
             child_tags = merged_tags + inc.tags
             child_deps = merged_deps + inc.dependencies
             child_base_url = (
-                inc.base_url
-                if inc.base_url is not None
-                else merged_base_url
+                inc.base_url if inc.base_url is not None else merged_base_url
             )
             routes.extend(
                 inc.router.build_routes(

--- a/fasthttp/security/ssrf.py
+++ b/fasthttp/security/ssrf.py
@@ -1,6 +1,7 @@
 import asyncio
 import ipaddress
 import socket
+import time
 from urllib.parse import urlparse
 
 try:
@@ -8,6 +9,7 @@ try:
         is_local_hostname as _rs_is_local_hostname,  # type: ignore
     )
     from fasthttp._core import is_private_ip as _rs_is_private_ip  # type: ignore
+
     _RUST = True
 except ImportError:
     _RUST = False
@@ -47,9 +49,23 @@ LOCALHOST_NAMES = [
 ]
 
 
+_DNS_TTL = 300.0
+
+
 class SSRFProtection:
-    def __init__(self) -> None:
-        self._dns_cache = {}
+    def __init__(self, dns_ttl: float = _DNS_TTL) -> None:
+        self._dns_cache: dict[str, tuple[str, float]] = {}
+        self._dns_ttl = dns_ttl
+
+    def _dns_lookup_cached(self, hostname: str) -> str:
+        entry = self._dns_cache.get(hostname)
+        if entry is not None:
+            ip, expiry = entry
+            if time.monotonic() < expiry:
+                return ip
+        ip = socket.gethostbyname(hostname)
+        self._dns_cache[hostname] = (ip, time.monotonic() + self._dns_ttl)
+        return ip
 
     async def check_url(self, url: str) -> bool:  # noqa: C901
         parsed = urlparse(url)
@@ -72,7 +88,7 @@ class SSRFProtection:
                 return False
 
         try:
-            ip_str = await asyncio.to_thread(socket.gethostbyname, hostname)
+            ip_str = await asyncio.to_thread(self._dns_lookup_cached, hostname)
 
             if _RUST:
                 if _rs_is_private_ip(ip_str):


### PR DESCRIPTION
 Summary

  - json → orjson across entire codebase — cli/commands.py, cli/output.py, cli/repl.py,
  openapi/routes.py, app.py. orjson is 2–10× faster than stdlib json, returns bytes directly (no
  encode overhead). All json.dumps(..., indent=2) → orjson.dumps(..., option=orjson.OPT_INDENT_2)
  - __slots__ on Response — eliminates __dict__ overhead; Response is created on every request, so
  attribute access speedup compounds under load
  - __slots__ on Route — same rationale; routes are accessed on every dispatch
  - OpenAPI schema cache — generate_openapi_schema was called on every /openapi.json hit. Now
  generated once on first request, cached as pre-serialized bytes in ASGIAdapter._openapi_cache.
  Subsequent hits skip both schema generation and JSON serialization
  - DNS cache in SSRFProtection — socket.gethostbyname result cached per hostname with 300s TTL
  (time.monotonic). Avoids redundant DNS round-trips for repeated requests to same host. TTL
  configurable via dns_ttl param

  Tooling

  - ty.toml — added Astral ty config (python-version = "3.10", unused-type-ignore-comment = "warn")
  - .pre-commit-config.yaml — ruff (lint + format) and ty hooks
  - All ty errors fixed — flattened fasthttp._core imports to single-line (ty ignores continuation
  lines in parenthesized imports); replaced # type: ignore[code] with bare # type: ignore (ty
  doesn't recognize mypy error codes)
  - CodeQL fix — "str" in dict → dict.get("str") is not None in tests/test_security.py to resolve
  py/incomplete-url-substring-sanitization false positive