### PR TITLE
Feat/response body methods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,3 +209,71 @@ jobs:
             --data-urlencode "text=${MESSAGE}" \
             -d "parse_mode=Markdown" \
             --data-urlencode "reply_markup=${KEYBOARD}"
+
+      - name: Email — released
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          to: ${{ secrets.EMAIL_TO }}
+          from: "fasthttp CI <${{ secrets.EMAIL_USERNAME }}>"
+          subject: "🚀 fasthttp-client v${{ needs.prepare.outputs.version }} released"
+          html_body: |
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta charset="utf-8">
+              <style>
+                body { margin: 0; padding: 0; background: #0d1117; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+                .wrap { max-width: 560px; margin: 40px auto; background: #161b22; border-radius: 12px; overflow: hidden; border: 1px solid #30363d; }
+                .hero { background: linear-gradient(135deg, #238636 0%, #1a7f37 100%); padding: 32px 32px 24px; }
+                .hero h1 { margin: 0; color: #fff; font-size: 24px; font-weight: 700; }
+                .hero .tag { display: inline-block; margin-top: 8px; background: rgba(255,255,255,.15); color: #fff; border-radius: 20px; padding: 4px 14px; font-size: 13px; font-weight: 600; }
+                .body { padding: 28px 32px; }
+                .desc { color: #8b949e; font-size: 14px; line-height: 1.6; margin: 0 0 24px; }
+                .meta { display: flex; gap: 24px; margin-bottom: 28px; }
+                .meta-item { flex: 1; }
+                .meta-item .label { color: #8b949e; font-size: 11px; text-transform: uppercase; letter-spacing: .6px; margin-bottom: 4px; }
+                .meta-item .value { color: #e6edf3; font-size: 14px; font-weight: 600; }
+                .btns { display: flex; gap: 10px; }
+                .btn { flex: 1; display: block; text-align: center; padding: 10px 0; border-radius: 8px; font-size: 13px; font-weight: 600; text-decoration: none; }
+                .btn-primary { background: #238636; color: #fff; }
+                .btn-secondary { background: #21262d; color: #e6edf3; border: 1px solid #30363d; }
+                .footer { padding: 16px 32px; border-top: 1px solid #21262d; color: #8b949e; font-size: 12px; text-align: center; }
+              </style>
+            </head>
+            <body>
+              <div class="wrap">
+                <div class="hero">
+                  <h1>fasthttp-client</h1>
+                  <span class="tag">v${{ needs.prepare.outputs.version }}</span>
+                </div>
+                <div class="body">
+                  <p class="desc">New version successfully built, published to PyPI and tagged on GitHub.</p>
+                  <div class="meta">
+                    <div class="meta-item">
+                      <div class="label">Released by</div>
+                      <div class="value">@${{ github.actor }}</div>
+                    </div>
+                    <div class="meta-item">
+                      <div class="label">Timestamp</div>
+                      <div class="value">${{ github.event.head_commit.timestamp }}</div>
+                    </div>
+                    <div class="meta-item">
+                      <div class="label">Commit</div>
+                      <div class="value">${{ needs.prepare.outputs.sha && needs.prepare.outputs.sha || github.sha }}</div>
+                    </div>
+                  </div>
+                  <div class="btns">
+                    <a class="btn btn-primary" href="https://pypi.org/project/fasthttp-client/">📦 PyPI</a>
+                    <a class="btn btn-secondary" href="https://github.com/${{ github.repository }}/releases/tag/v${{ needs.prepare.outputs.version }}">💻 Release</a>
+                    <a class="btn btn-secondary" href="https://fasthttp.ndugram.dev">📖 Docs</a>
+                  </div>
+                </div>
+                <div class="footer">fasthttp-client · GitHub Actions · ${{ github.repository }}</div>
+              </div>
+            </body>
+            </html>

--- a/docs/en/reference/response.md
+++ b/docs/en/reference/response.md
@@ -7,9 +7,8 @@ Response object reference.
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `status` | `int` | HTTP status code |
-| `text` | `str` | Raw response body |
+| `text` | `str` | Raw response body as string |
 | `headers` | `dict` | Response headers |
-| `content` | `bytes` | Raw bytes |
 | `method` | `str` | HTTP method |
 | `url` | `str` | Request URL |
 
@@ -38,6 +37,61 @@ Get request body as text:
 ```python
 sent = resp.req_text()  # Returns str or None
 ```
+
+### bytes()
+
+Returns the raw response body as bytes. Uses the actual bytes received from the server; falls back to `text.encode()` if unavailable:
+
+```python
+raw = resp.bytes()  # Returns bytes
+```
+
+**Use cases:** downloading images, PDFs, zip files, any binary content.
+
+```python
+@app.get(url="https://httpbin.org/image/png")
+async def handler(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {"size": len(raw), "is_png": raw[:4] == b"\x89PNG"}
+```
+
+### html()
+
+Returns the response body as an HTML string. Raises `ValueError` if `Content-Type` is not HTML:
+
+```python
+html = resp.html()  # Returns str
+```
+
+**Raises:** `ValueError` — if `Content-Type` is present and does not contain `html`.
+
+```python
+@app.get(url="https://example.com")
+async def handler(resp: Response) -> dict:
+    html = resp.html()
+    return {"length": len(html)}
+```
+
+### xml()
+
+Parses the response body as XML and returns the root `xml.etree.ElementTree.Element`:
+
+```python
+root = resp.xml()  # Returns ET.Element
+```
+
+**Raises:** `xml.etree.ElementTree.ParseError` — if the body is not valid XML.
+
+```python
+@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
+async def handler(resp: Response) -> dict:
+    root = resp.xml()
+    channel = root.find("channel")
+    return {"title": channel.findtext("title")}
+```
+
+!!! warning
+    Uses the stdlib XML parser — vulnerable to XXE attacks. Only use with trusted sources.
 
 ### assets()
 

--- a/docs/en/tutorial/response-handling.md
+++ b/docs/en/tutorial/response-handling.md
@@ -19,8 +19,8 @@ async def handle_response(resp: Response) -> dict:
     # Response headers
     headers = resp.headers
     
-    # Raw content
-    content = resp.content
+    # Raw bytes
+    raw = resp.bytes()
     
     return {"status": status, "data": data}
 ```
@@ -60,6 +60,58 @@ Returns request body as text:
 # For POST request with data=b"raw data"
 sent = resp.req_text()  # Returns "raw data"
 ```
+
+### bytes()
+
+Returns the raw response body as bytes. Use for binary responses like images, PDFs, or archives:
+
+```python
+@app.get(url="https://httpbin.org/image/png")
+async def download_image(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {
+        "size": len(raw),
+        "is_png": raw[:4] == b"\x89PNG",
+    }
+```
+
+### html()
+
+Returns the response body as an HTML string. Raises `ValueError` if the `Content-Type` is not HTML — useful to catch accidental calls on JSON endpoints:
+
+```python
+@app.get(url="https://example.com")
+async def get_page(resp: Response) -> dict:
+    html = resp.html()
+    return {"length": len(html)}
+```
+
+```python
+# Raises ValueError: Expected HTML response, got Content-Type: application/json
+@app.get(url="https://api.example.com/users")
+async def wrong_call(resp: Response):
+    return resp.html()
+```
+
+### xml()
+
+Parses the response body as XML and returns the root `Element`. Works for any XML-based format including RSS and Atom feeds:
+
+```python
+@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
+async def get_rss(resp: Response) -> dict:
+    root = resp.xml()
+    channel = root.find("channel")
+    items = channel.findall("item")
+    return {
+        "feed": channel.findtext("title"),
+        "count": len(items),
+        "latest": [i.findtext("title") for i in items[:3]],
+    }
+```
+
+!!! warning
+    `xml()` uses the standard library XML parser which is vulnerable to entity expansion attacks (XXE). Only use it with **trusted sources**. For untrusted data, use `defusedxml`.
 
 ### assets()
 
@@ -119,7 +171,7 @@ async def check_response(resp: Response) -> dict | None:
 | `status` | `int` | HTTP status code |
 | `text` | `str` | Raw response body |
 | `headers` | `dict` | Response headers |
-| `content` | `bytes` | Raw bytes |
+| `bytes()` | `bytes` | Raw response body as bytes |
 | `method` | `str` | HTTP method used |
 
 ## Complete Example

--- a/docs/ru/reference/response.md
+++ b/docs/ru/reference/response.md
@@ -7,9 +7,8 @@
 | Атрибут | Тип | Описание |
 |---------|-----|----------|
 | `status` | `int` | Код статуса HTTP |
-| `text` | `str` | Сырое тело ответа |
+| `text` | `str` | Сырое тело ответа строкой |
 | `headers` | `dict` | Заголовки ответа |
-| `content` | `bytes` | Сырые байты |
 | `method` | `str` | HTTP метод |
 | `url` | `str` | URL запроса |
 
@@ -30,6 +29,61 @@ data = resp.json()  # Возвращает dict или list
 ```python
 sent = resp.req_json()  # Возвращает dict или None
 ```
+
+### bytes()
+
+Возвращает тело ответа в виде байт. Использует реальные байты от сервера; при недоступности — кодирует `text` в UTF-8:
+
+```python
+raw = resp.bytes()  # Возвращает bytes
+```
+
+**Применение:** загрузка изображений, PDF, zip-файлов и любого бинарного контента.
+
+```python
+@app.get(url="https://httpbin.org/image/png")
+async def handler(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {"size": len(raw), "is_png": raw[:4] == b"\x89PNG"}
+```
+
+### html()
+
+Возвращает тело ответа как HTML-строку. Бросает `ValueError`, если `Content-Type` не является HTML:
+
+```python
+html = resp.html()  # Возвращает str
+```
+
+**Бросает:** `ValueError` — если `Content-Type` присутствует и не содержит `html`.
+
+```python
+@app.get(url="https://example.com")
+async def handler(resp: Response) -> dict:
+    html = resp.html()
+    return {"length": len(html)}
+```
+
+### xml()
+
+Парсит тело ответа как XML и возвращает корневой `xml.etree.ElementTree.Element`:
+
+```python
+root = resp.xml()  # Возвращает ET.Element
+```
+
+**Бросает:** `xml.etree.ElementTree.ParseError` — если тело не является валидным XML.
+
+```python
+@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
+async def handler(resp: Response) -> dict:
+    root = resp.xml()
+    channel = root.find("channel")
+    return {"title": channel.findtext("title")}
+```
+
+!!! warning
+    Использует стандартный XML-парсер — уязвим к XXE-атакам. Используйте только с доверенными источниками.
 
 ### assets()
 

--- a/docs/ru/tutorial/response-handling.md
+++ b/docs/ru/tutorial/response-handling.md
@@ -20,7 +20,7 @@ async def handle_response(resp: Response) -> dict:
     headers = resp.headers
     
     # Сырые байты
-    content = resp.content
+    raw = resp.bytes()
     
     return {"status": status, "data": data}
 ```
@@ -51,6 +51,58 @@ text = resp.text  # Возвращает str
 # Для POST запроса с json={"name": "John"}
 sent = resp.req_json()  # Возвращает {"name": "John"}
 ```
+
+### bytes()
+
+Возвращает тело ответа в виде байт. Используйте для бинарных ответов — изображений, PDF, архивов:
+
+```python
+@app.get(url="https://httpbin.org/image/png")
+async def download_image(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {
+        "size": len(raw),
+        "is_png": raw[:4] == b"\x89PNG",
+    }
+```
+
+### html()
+
+Возвращает тело ответа в виде HTML-строки. Бросает `ValueError`, если `Content-Type` не является HTML — полезно для защиты от случайного вызова на JSON-эндпоинтах:
+
+```python
+@app.get(url="https://example.com")
+async def get_page(resp: Response) -> dict:
+    html = resp.html()
+    return {"length": len(html)}
+```
+
+```python
+# Бросает ValueError: Expected HTML response, got Content-Type: application/json
+@app.get(url="https://api.example.com/users")
+async def wrong_call(resp: Response):
+    return resp.html()
+```
+
+### xml()
+
+Парсит тело ответа как XML и возвращает корневой `Element`. Работает с любым XML-форматом, включая RSS и Atom:
+
+```python
+@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
+async def get_rss(resp: Response) -> dict:
+    root = resp.xml()
+    channel = root.find("channel")
+    items = channel.findall("item")
+    return {
+        "feed": channel.findtext("title"),
+        "count": len(items),
+        "latest": [i.findtext("title") for i in items[:3]],
+    }
+```
+
+!!! warning
+    `xml()` использует стандартный XML-парсер, уязвимый к атакам с раскрытием внешних сущностей (XXE). Используйте только с **доверенными источниками**. Для недоверенных данных используйте `defusedxml`.
 
 ### assets()
 
@@ -110,5 +162,5 @@ async def check_response(resp: Response) -> dict | None:
 | `status` | `int` | Код статуса HTTP |
 | `text` | `str` | Сырое тело ответа |
 | `headers` | `dict` | Заголовки ответа |
-| `content` | `bytes` | Сырые байты |
+| `bytes()` | `bytes` | Сырое тело ответа в байтах |
 | `method` | `str` | Используемый HTTP метод |

--- a/examples/data/binary_responses.py
+++ b/examples/data/binary_responses.py
@@ -1,0 +1,77 @@
+"""
+Examples for response.bytes(), response.html(), response.xml().
+
+Real endpoints used:
+  bytes() → https://httpbin.org/image/png    (PNG image)
+  html()  → https://example.com              (plain HTML page)
+  xml()   → https://httpbin.org/xml          (XML document)
+"""
+
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP(debug=True)
+
+
+# --- bytes() ---
+
+
+@app.get(url="https://httpbin.org/image/png")
+async def download_png(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {
+        "size_bytes": len(raw),
+        "is_png": raw[:4] == b"\x89PNG",
+        "content_type": resp.headers.get("content-type"),
+    }
+
+
+@app.get(url="https://httpbin.org/bytes/32")
+async def download_random_bytes(resp: Response) -> dict:
+    raw = resp.bytes()
+    return {"size_bytes": len(raw), "hex_preview": raw[:8].hex()}
+
+
+# --- html() ---
+
+
+@app.get(url="https://example.com")
+async def get_html_page(resp: Response) -> dict:
+    html = resp.html()
+    return {
+        "length": len(html),
+        "starts_with_doctype": html.strip().lower().startswith("<!doctype"),
+        "content_type": resp.headers.get("content-type"),
+    }
+
+
+# --- xml() ---
+
+
+@app.get(url="https://httpbin.org/xml")
+async def get_xml(resp: Response) -> dict:
+    root = resp.xml()
+    return {
+        "root_tag": root.tag,
+        "children_count": len(root),
+        "content_type": resp.headers.get("content-type"),
+    }
+
+
+@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
+async def get_bbc_rss(resp: Response) -> dict:
+    root = resp.xml()
+    channel = root.find("channel")
+    if channel is None:
+        return {"error": "no channel element"}
+    items = channel.findall("item")
+    titles = [item.findtext("title") for item in items[:5]]
+    return {
+        "feed_title": channel.findtext("title"),
+        "item_count": len(items),
+        "latest_titles": titles,
+    }
+
+
+if __name__ == "__main__":
+    app.run()

--- a/fasthttp/_core/src/response_check.rs
+++ b/fasthttp/_core/src/response_check.rs
@@ -94,7 +94,17 @@ pub fn validate_response(
         }
     }
 
-    if content.contains(&b'<') && content.contains(&b'>') {
+    // Skip XSS scan for markup content types — scripts/events are expected there.
+    // XSS detection is only meaningful for non-markup API responses (e.g. JSON).
+    let is_markup = content_type.map_or(false, |ct| {
+        let ct_lower = ct.to_lowercase();
+        ct_lower.contains("html")
+            || ct_lower.contains("xml")
+            || ct_lower.contains("rss")
+            || ct_lower.contains("atom")
+    });
+
+    if !is_markup && content.contains(&b'<') && content.contains(&b'>') {
         if let Ok(text) = std::str::from_utf8(content) {
             let (found, reason) = detect_xss(text);
             if found {

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -247,6 +247,7 @@ class HTTPClient:
             query=route.params,
             req_json=route.json,
             req_data=route.data,
+            content=response.content,
         )
         resp._url = route.url  # noqa: SLF001
         return resp

--- a/fasthttp/response.py
+++ b/fasthttp/response.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET
 from typing import Annotated, Any
 
 import orjson
@@ -46,6 +47,7 @@ class Response:
         query: Annotated[dict | None, Doc("Query parameters encoded into the request URL.")] = None,
         req_json: Annotated[dict | None, Doc("JSON body sent with the request.")] = None,
         req_data: Annotated[object | None, Doc("Raw body or form data sent with the request.")] = None,
+        content: Annotated[bytes | None, Doc("Raw response body as bytes.")] = None,
     ) -> None:
         self.status = status
         self.text = text
@@ -57,6 +59,7 @@ class Response:
         self._req_json = req_json
         self._req_data = req_data
         self._url: str | None = None
+        self._content: bytes | None = content
 
     def _set_url(self, url: str | None) -> None:
         self._url = url
@@ -113,6 +116,33 @@ class Response:
         if self._req_data is not None:
             return str(self._req_data)
         return None
+
+    def bytes(self) -> bytes:
+        """Return raw response body as bytes."""
+        if self._content is not None:
+            return self._content
+        return self.text.encode()
+
+    def html(self) -> str:
+        """Return response body as HTML string.
+
+        Raises ValueError if Content-Type is not HTML.
+        """
+        content_type = self.headers.get("content-type", "")
+        if content_type and "html" not in content_type.lower():
+            msg = f"Expected HTML response, got Content-Type: {content_type}"
+            raise ValueError(msg)
+        return self.text
+
+    def xml(self) -> ET.Element:
+        """Parse response body as XML and return root Element.
+
+        Only use with trusted sources — stdlib XML parser is vulnerable to
+        entity expansion attacks (XXE). For untrusted data, use defusedxml.
+
+        Raises xml.etree.ElementTree.ParseError on invalid XML.
+        """
+        return ET.fromstring(self.text)  # noqa: S314
 
     def assets(self, *, css: bool = True, js: bool = True) -> dict[str, list[str]]:
         """Extract CSS and JS asset URLs from the response HTML."""

--- a/fasthttp/security/response.py
+++ b/fasthttp/security/response.py
@@ -134,7 +134,14 @@ class ResponseProtection:
             if not ct_check[0]:
                 return ct_check
 
-        if b"<" in content and b">" in content:
+        is_markup = bool(
+            content_type
+            and any(
+                t in content_type.lower()
+                for t in ("html", "xml", "rss", "atom")
+            )
+        )
+        if not is_markup and b"<" in content and b">" in content:
             try:
                 text = content.decode("utf-8", errors="ignore")
                 xss_check = self.detect_xss(text)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,4 +1,5 @@
 import json
+import xml.etree.ElementTree as ET
 
 import pytest
 
@@ -282,3 +283,126 @@ class TestResponseDefaults:
         for status in [200, 201, 400, 404, 500]:
             r = Response(status=status, text="", headers={})
             assert repr(r) == f"<Response [{status}]>"
+
+
+class TestResponseBytes:
+    def test_bytes_returns_stored_content(self):
+        raw = b"\x89PNG\r\n\x1a\n"
+        r = Response(status=200, text="", headers={}, content=raw)
+        assert r.bytes() == raw
+
+    def test_bytes_falls_back_to_text_encode(self):
+        r = Response(status=200, text="hello", headers={})
+        assert r.bytes() == b"hello"
+
+    def test_bytes_utf8_text_fallback(self):
+        r = Response(status=200, text="привет", headers={})
+        assert r.bytes() == "привет".encode()
+
+    def test_bytes_empty_content(self):
+        r = Response(status=200, text="", headers={}, content=b"")
+        assert r.bytes() == b""
+
+    def test_bytes_binary_content_not_decodable_as_text(self):
+        raw = bytes(range(256))
+        r = Response(status=200, text="", headers={}, content=raw)
+        assert r.bytes() == raw
+
+    def test_content_default_is_none(self):
+        r = Response(status=200, text="", headers={})
+        assert r._content is None
+
+    def test_bytes_prefers_content_over_text(self):
+        raw = b"binary"
+        r = Response(status=200, text="text", headers={}, content=raw)
+        assert r.bytes() == b"binary"
+
+
+class TestResponseHtml:
+    def test_html_returns_text(self):
+        html = "<html><body>Hello</body></html>"
+        r = Response(status=200, text=html, headers={"content-type": "text/html"})
+        assert r.html() == html
+
+    def test_html_with_charset_in_content_type(self):
+        html = "<p>test</p>"
+        r = Response(
+            status=200,
+            text=html,
+            headers={"content-type": "text/html; charset=utf-8"},
+        )
+        assert r.html() == html
+
+    def test_html_no_content_type_allowed(self):
+        r = Response(status=200, text="<p>ok</p>", headers={})
+        assert r.html() == "<p>ok</p>"
+
+    def test_html_raises_on_json_content_type(self):
+        r = Response(
+            status=200,
+            text='{"key": "val"}',
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ValueError, match="Expected HTML"):
+            r.html()
+
+    def test_html_raises_on_xml_content_type(self):
+        r = Response(
+            status=200,
+            text="<root/>",
+            headers={"content-type": "application/xml"},
+        )
+        with pytest.raises(ValueError, match="Expected HTML"):
+            r.html()
+
+    def test_html_xhtml_content_type_allowed(self):
+        r = Response(
+            status=200,
+            text="<html/>",
+            headers={"content-type": "application/xhtml+xml"},
+        )
+        # xhtml contains "html" → should NOT raise
+        assert r.html() == "<html/>"
+
+
+class TestResponseXml:
+    def test_xml_returns_element(self):
+        r = Response(status=200, text="<root><item>1</item></root>", headers={})
+        el = r.xml()
+        assert isinstance(el, ET.Element)
+        assert el.tag == "root"
+
+    def test_xml_parses_children(self):
+        r = Response(
+            status=200,
+            text="<users><user id='1'>Alice</user><user id='2'>Bob</user></users>",
+            headers={},
+        )
+        root = r.xml()
+        assert len(root) == 2
+        assert root[0].text == "Alice"
+        assert root[1].get("id") == "2"
+
+    def test_xml_raises_on_invalid_xml(self):
+        r = Response(status=200, text="not xml at all", headers={})
+        with pytest.raises(ET.ParseError):
+            r.xml()
+
+    def test_xml_self_closing_tag(self):
+        r = Response(status=200, text="<empty/>", headers={})
+        el = r.xml()
+        assert el.tag == "empty"
+        assert len(el) == 0
+
+    def test_xml_rss_like_structure(self):
+        rss = (
+            "<rss version='2.0'>"
+            "<channel><title>Feed</title><item><title>Post 1</title></item></channel>"
+            "</rss>"
+        )
+        r = Response(status=200, text=rss, headers={})
+        root = r.xml()
+        assert root.tag == "rss"
+        channel = root.find("channel")
+        assert channel is not None
+        assert channel.findtext("title") == "Feed"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "fasthttp-client"
-version = "1.3.0"
+version = "1.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## 🚀 Description

Added three new response body methods — `bytes()`, `html()`, and `xml()` — to the `Response` class. Previously only `.text` and `.json()` were available, which made it impossible to work with binary responses (images, files) or properly parse XML/HTML pages.

Also fixed a false-positive XSS security error that blocked fetching any HTML or XML/RSS content. The XSS scan was running on all response types regardless of `Content-Type`, causing `SecurityError: Potential XSS detected in response` even for legitimate HTML page fetches. The fix skips XSS detection for markup content types (`text/html`, `application/xml`, `application/rss+xml`, etc.) since scripts and event handlers are expected in those formats — XSS detection only makes sense for JSON/API responses.

Added email release notifications to the CI/CD pipeline alongside the existing Telegram notification.

---

## 🧩 Type of Change

- [x] feat: New feature
- [x] fix: Bug fix
- [x] ci: CI/CD changes

---

## ✅ Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

### New `Response` methods

**`response.bytes() → bytes`**
Returns the raw response body as bytes. Uses the actual bytes from the HTTP response if available, falls back to `text.encode()` otherwise. Essential for binary content like images, PDFs, archives.

```python
@app.get(url="https://httpbin.org/image/png")
async def download_png(resp: Response) -> dict:
    raw = resp.bytes()
    return {"size": len(raw), "is_png": raw[:4] == b"\x89PNG"}
```

**`response.html() → str`**
Returns the response body as an HTML string. Raises `ValueError` if `Content-Type` is not HTML (e.g. accidentally calling `.html()` on a JSON endpoint).

```python
@app.get(url="https://example.com")
async def get_page(resp: Response) -> dict:
    html = resp.html()
    return {"length": len(html)}
```

**`response.xml() → xml.etree.ElementTree.Element`**
Parses the response body as XML and returns the root element. Works for any XML-based format including RSS and Atom feeds.

```python
@app.get(url="https://feeds.bbci.co.uk/news/rss.xml")
async def get_rss(resp: Response) -> dict:
    root = resp.xml()
    channel = root.find("channel")
    return {"title": channel.findtext("title")}
```

### Security fix — XSS false positive

`validate_response` in both Rust (`_core/src/response_check.rs`) and the Python fallback (`security/response.py`) now skips XSS scanning when `Content-Type` contains `html`, `xml`, `rss`, or `atom`. JSON and other non-markup types are still scanned.

### New tests — 17 added

- `TestResponseBytes` (7) — binary content, fallback to text encode, preference over text
- `TestResponseHtml` (6) — content-type validation, xhtml passthrough, ValueError on JSON ct
- `TestResponseXml` (5) — parsing, children traversal, RSS structure, ParseError on invalid XML

### CI/CD — email notifications

Added `dawidd6/action-send-mail@v3` step to the `publish` job in `release.yml`. Sends a dark-themed HTML email (GitHub-style) on every release with version, author, timestamp, commit SHA, and links to PyPI / GitHub Release / Docs.
