### PR TITLE
feat: add raise_for_status option to FastHTTP and HTTPClient

### DIFF
--- a/examples/error/raise_for_status.py
+++ b/examples/error/raise_for_status.py
@@ -1,0 +1,27 @@
+from fasthttp import FastHTTP
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP(debug=True, raise_for_status=True)
+
+
+@app.get(url="https://httpbin.org/status/404")
+async def not_found(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://httpbin.org/status/500")
+async def server_error(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://httpbin.org/get")
+async def success(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"Caught error: HTTP {e.status_code} — {e.url}")

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -261,6 +261,34 @@ class FastHTTP:
                 """
             ),
         ] = True,
+        raise_for_status: Annotated[
+            bool,
+            Doc(
+                """
+                Raise FastHTTPBadStatusError on 4xx/5xx responses.
+
+                When True, any response with a status code >= 400 will raise
+                FastHTTPBadStatusError instead of silently returning None.
+
+                Useful when you want to handle HTTP errors via try/except
+                rather than checking for None returns.
+
+                Example:
+                ```python
+                app = FastHTTP(raise_for_status=True)
+
+                @app.get("https://api.example.com/users")
+                async def get_users(resp: Response) -> list:
+                    return resp.json()
+
+                try:
+                    app.run()
+                except FastHTTPBadStatusError as e:
+                    print(e.status_code)
+                ```
+                """
+            ),
+        ] = False,
         lifespan: Annotated[
             Callable[[FastHTTP], object] | None,
             Doc(
@@ -421,6 +449,7 @@ class FastHTTP:
         }
 
         self.security_enabled = security
+        self.raise_for_status = raise_for_status
         self.secret_key = secret_key or secrets.token_bytes(32)
         self.security = Security(secret_key=self.secret_key) if security else None
         self.startup_uuid = None
@@ -439,6 +468,7 @@ class FastHTTP:
             self.middleware_manager,
             self.security,
             self.startup_uuid,
+            raise_for_status=self.raise_for_status,
         )
 
     def _check_annotated_parameters(
@@ -1020,12 +1050,15 @@ class FastHTTP:
         ) as client:
             if total > 1:
                 if sys.version_info >= (3, 11):
-                    async with asyncio.TaskGroup() as tg:
-                        tg_tasks = [
-                            tg.create_task(self._run_route(client, route))
-                            for route in routes
-                        ]
-                    results = [t.result() for t in tg_tasks]
+                    try:
+                        async with asyncio.TaskGroup() as tg:
+                            tg_tasks = [
+                                tg.create_task(self._run_route(client, route))
+                                for route in routes
+                            ]
+                        results = [t.result() for t in tg_tasks]
+                    except BaseExceptionGroup as eg:
+                        raise eg.exceptions[0] from None
                 else:
                     results = await asyncio.gather(
                         *[self._run_route(client, route) for route in routes]

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -87,12 +87,27 @@ class HTTPClient:
                 """
             ),
         ] = None,
+        *,
+        raise_for_status: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to raise FastHTTPBadStatusError on 4xx/5xx responses.
+
+                When True, any response with a status code >= 400 will raise
+                FastHTTPBadStatusError instead of returning None.
+
+                Defaults to False.
+                """
+            ),
+        ] = False,
     ) -> None:
         self.request_configs = request_configs
         self.logger = logger
         self.middleware_manager = middleware_manager
         self.security = security
         self.startup_uuid = startup_uuid
+        self.raise_for_status = raise_for_status
 
     def _validate_request(self, route: Route) -> bool:
         if not route.request_model:
@@ -215,6 +230,9 @@ class HTTPClient:
 
         if self.middleware_manager:
             await self.middleware_manager.process_on_error(error, route, config)  # type: ignore
+
+        if self.raise_for_status:
+            raise error
 
     async def _handle_error(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from fasthttp.__meta__ import __version__
 from fasthttp.client import HTTPClient
+from fasthttp.exceptions import FastHTTPBadStatusError
 from fasthttp.middleware import MiddlewareManager as MM  # noqa: N817
 from fasthttp.response import Response
 from fasthttp.routing import Route
@@ -297,3 +298,118 @@ class TestHTTPClient:
 
         assert result == custom_response
         assert result.status == 201
+
+    @pytest.mark.asyncio
+    async def test_raise_for_status_false_returns_none_on_4xx(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that raise_for_status=False (default) returns None on 4xx."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_response.headers = {}
+        mock_response.content = b"Not Found"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=False,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/notfound", handler=handler)
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raise_for_status_true_raises_on_4xx(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that raise_for_status=True raises FastHTTPBadStatusError on 4xx."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_response.headers = {}
+        mock_response.content = b"Not Found"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=True,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/notfound", handler=handler)
+
+        with pytest.raises(FastHTTPBadStatusError) as exc_info:
+            await client.send(mock_httpx_client, route)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_raise_for_status_true_raises_on_5xx(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that raise_for_status=True raises FastHTTPBadStatusError on 5xx."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.headers = {}
+        mock_response.content = b"Internal Server Error"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=True,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/error", handler=handler)
+
+        with pytest.raises(FastHTTPBadStatusError) as exc_info:
+            await client.send(mock_httpx_client, route)
+
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_raise_for_status_true_no_raise_on_2xx(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that raise_for_status=True does NOT raise on 2xx."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"ok": true}'
+        mock_response.headers = {}
+        mock_response.content = b'{"ok": true}'
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=True,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/ok", handler=handler)
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is not None
+        assert result.status == 200


### PR DESCRIPTION
## 🚀 Description
Adds `raise_for_status` flag to `FastHTTP` and `HTTPClient`.
When `True`, any 4xx/5xx response raises `FastHTTPBadStatusError`
instead of silently returning `None`.

Also fixes `ExceptionGroup` unwrapping when multiple routes fail under
`asyncio.TaskGroup` (Python 3.11+) — previously `except FastHTTPBadStatusError`
would not catch the error because `TaskGroup` wrapped it in `BaseExceptionGroup`.

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

```python
app = FastHTTP(raise_for_status=True)

@app.get("https://api.example.com/users")
async def get_users(resp: Response) -> list:
    return resp.json()

try:
    app.run()
except FastHTTPBadStatusError as e:
    print(f"HTTP {e.status_code} — {e.url}")
```
