### PR TITLE
Feat/raise for status in router

### DIFF
--- a/docs/en/tutorial/configuration/settings.md
+++ b/docs/en/tutorial/configuration/settings.md
@@ -8,17 +8,18 @@ Basic application configuration.
 from fasthttp import FastHTTP
 
 app = FastHTTP(
-    debug=False,      # Debug mode
-    http2=False,      # Use HTTP/2
-    proxy=None,       # Proxy server
-    security=True,    # Enable security
-    lifespan=None,    # Lifespan context manager
-    middleware=[],    # Middleware list
-    get_request={},   # Default GET settings
-    post_request={},  # Default POST settings
-    put_request={},   # Default PUT settings
-    patch_request={}, # Default PATCH settings
-    delete_request={} # Default DELETE settings
+    debug=False,             # Debug mode
+    http2=False,             # Use HTTP/2
+    proxy=None,              # Proxy server
+    security=True,           # Enable security
+    lifespan=None,           # Lifespan context manager
+    middleware=[],           # Middleware list
+    raise_for_status=False,  # Raise on 4xx/5xx
+    get_request={},          # Default GET settings
+    post_request={},         # Default POST settings
+    put_request={},          # Default PUT settings
+    patch_request={},        # Default PATCH settings
+    delete_request={}        # Default DELETE settings
 )
 ```
 
@@ -32,6 +33,7 @@ app = FastHTTP(
 | `security` | `bool` | `True` | Enable security features |
 | `lifespan` | `Callable` | `None` | Startup/shutdown handler |
 | `middleware` | `list` | `[]` | Middleware instances |
+| `raise_for_status` | `bool` | `False` | Raise `FastHTTPBadStatusError` on 4xx/5xx for all routes |
 | `get_request` | `dict` | `{}` | Default GET settings |
 | `post_request` | `dict` | `{}` | Default POST settings |
 | `put_request` | `dict` | `{}` | Default PUT settings |

--- a/docs/en/tutorial/response-handling.md
+++ b/docs/en/tutorial/response-handling.md
@@ -164,6 +164,52 @@ async def check_response(resp: Response) -> dict | None:
     return resp.json()
 ```
 
+### raise_for_status
+
+By default, 4xx and 5xx responses are logged and the handler receives `None`. Enable `raise_for_status` to raise `FastHTTPBadStatusError` instead.
+
+#### Global — all routes
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP(raise_for_status=True)
+
+
+@app.get(url="https://api.example.com/users")
+async def get_users(resp: Response) -> list:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"HTTP {e.status_code} on {e.url}")
+```
+
+#### Per-route — only specific routes
+
+```python
+app = FastHTTP()
+
+
+@app.get(url="https://api.example.com/critical", raise_for_status=True)
+async def critical(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/optional")
+async def optional(resp: Response) -> dict | None:
+    if resp is None:
+        return None
+    return resp.json()
+```
+
+`FastHTTPBadStatusError` has `.status_code`, `.url`, `.method`, and `.response_body` attributes.
+
 ## Response Properties
 
 | Property | Type | Description |

--- a/docs/en/tutorial/routers.md
+++ b/docs/en/tutorial/routers.md
@@ -267,6 +267,42 @@ async def other_api(resp: Response) -> dict:
     return resp.json()
 ```
 
+## raise_for_status on Router Routes
+
+`raise_for_status` can be set per-route on a router decorator. When `True`, that route raises `FastHTTPBadStatusError` on 4xx/5xx instead of returning `None`.
+
+```python
+from fasthttp import FastHTTP, Router
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP()
+payments = Router(base_url="https://api.example.com", prefix="/payments")
+
+
+@payments.post("/charge", raise_for_status=True)
+async def charge(resp: Response) -> dict:
+    return resp.json()
+
+
+@payments.get("/history")
+async def history(resp: Response) -> dict | None:
+    if resp is None:
+        return None
+    return resp.json()
+
+
+app.include_router(payments)
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"Payment failed: HTTP {e.status_code}")
+```
+
+This works alongside the global `FastHTTP(raise_for_status=True)` flag — either being `True` is enough to raise.
+
 ## When to Use Routers
 
 Use routers when your project has:

--- a/examples/error/raise_for_status_per_route.py
+++ b/examples/error/raise_for_status_per_route.py
@@ -1,0 +1,27 @@
+from fasthttp import FastHTTP
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP(debug=True)
+
+
+@app.get(url="https://httpbin.org/status/404", raise_for_status=True)
+async def not_found(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://httpbin.org/status/500", raise_for_status=True)
+async def server_error(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://httpbin.org/get")
+async def success(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"Caught error: HTTP {e.status_code} — {e.url}")

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -577,6 +577,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
@@ -594,6 +595,7 @@ class FastHTTP:
                     request_model=request_model,
                     tags=tags,
                     dependencies=dependencies,
+                    raise_for_status=raise_for_status,
                     responses=responses,
                 )
             )
@@ -704,6 +706,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -714,6 +717,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -727,6 +731,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -738,6 +743,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -751,6 +757,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -762,6 +769,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -775,6 +783,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -786,6 +795,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -799,6 +809,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -810,6 +821,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -822,6 +834,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -832,6 +845,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -844,6 +858,7 @@ class FastHTTP:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -854,6 +869,7 @@ class FastHTTP:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -231,7 +231,7 @@ class HTTPClient:
         if self.middleware_manager:
             await self.middleware_manager.process_on_error(error, route, config)  # type: ignore
 
-        if self.raise_for_status:
+        if self.raise_for_status or route.raise_for_status:
             raise error
 
     async def _handle_error(

--- a/fasthttp/routing.py
+++ b/fasthttp/routing.py
@@ -68,6 +68,9 @@ class Route(BaseModel):
     skip_request: bool = False
     """When True, skips HTTP execution — handler is responsible for the request."""
 
+    raise_for_status: bool = False
+    """When True, raises FastHTTPBadStatusError on 4xx/5xx for this route only."""
+
     responses: dict[int, dict[Literal["model"], type[BaseModel]]] = Field(
         default_factory=dict
     )
@@ -99,6 +102,7 @@ class Route(BaseModel):
             tags: list[str] | None = None,
             dependencies: list[Any] | None = None,
             skip_request: bool = False,
+            raise_for_status: bool = False,
             responses: dict[int, dict[Literal["model"], type[BaseModel]]]
             | None = None,
         ) -> None:
@@ -115,6 +119,7 @@ class Route(BaseModel):
                 dependencies=dependencies,
                 skip_request=skip_request,
                 responses=responses,
+                raise_for_status=raise_for_status
             )
 
 
@@ -133,6 +138,7 @@ class _RouteDef:
     tags: list[str]
     dependencies: list[Any]
     skip_request: bool
+    raise_for_status: bool
     responses: dict[int, dict[Literal["model"], type[BaseModel]]]
 
 
@@ -218,6 +224,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         skip_request: bool = False,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
@@ -235,6 +242,7 @@ class Router:
                     tags=tags or [],
                     dependencies=dependencies or [],
                     skip_request=skip_request,
+                    raise_for_status=raise_for_status,
                     responses=responses or {},
                 )
             )
@@ -251,6 +259,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a GET route on the router."""
@@ -262,6 +271,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -275,6 +285,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a POST route on the router."""
@@ -287,6 +298,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -300,6 +312,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a PUT route on the router."""
@@ -312,6 +325,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -325,6 +339,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a PATCH route on the router."""
@@ -337,6 +352,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -350,6 +366,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a DELETE route on the router."""
@@ -362,6 +379,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -374,6 +392,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a HEAD route on the router."""
@@ -385,6 +404,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -397,6 +417,7 @@ class Router:
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
+        raise_for_status: bool = False,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering an OPTIONS route on the router."""
@@ -408,6 +429,7 @@ class Router:
             request_model=request_model,
             tags=tags,
             dependencies=dependencies,
+            raise_for_status=raise_for_status,
             responses=responses,
         )
 
@@ -453,6 +475,7 @@ class Router:
                     tags=route_tags,
                     dependencies=route_deps,
                     skip_request=rd.skip_request,
+                    raise_for_status=rd.raise_for_status,
                     responses=rd.responses,
                 )
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -413,3 +413,104 @@ class TestHTTPClient:
 
         assert result is not None
         assert result.status == 200
+
+    @pytest.mark.asyncio
+    async def test_route_raise_for_status_raises_when_global_false(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that route-level raise_for_status=True raises even when global is False."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_response.headers = {}
+        mock_response.content = b"Not Found"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=False,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(
+            method="GET",
+            url="http://example.com/notfound",
+            handler=handler,
+            raise_for_status=True,
+        )
+
+        with pytest.raises(FastHTTPBadStatusError) as exc_info:
+            await client.send(mock_httpx_client, route)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_route_raise_for_status_global_true_route_false_still_raises(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that global raise_for_status=True raises even when route flag is False."""
+        mock_response = MagicMock()
+        mock_response.status_code = 422
+        mock_response.text = "Unprocessable Entity"
+        mock_response.headers = {}
+        mock_response.content = b"Unprocessable Entity"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=True,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(
+            method="GET",
+            url="http://example.com/validate",
+            handler=handler,
+            raise_for_status=False,
+        )
+
+        with pytest.raises(FastHTTPBadStatusError) as exc_info:
+            await client.send(mock_httpx_client, route)
+
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_route_raise_for_status_both_false_returns_none(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """Test that both global and route raise_for_status=False returns None on 4xx."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+        mock_response.headers = {}
+        mock_response.content = b"Forbidden"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=False,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(
+            method="GET",
+            url="http://example.com/forbidden",
+            handler=handler,
+            raise_for_status=False,
+        )
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is None


### PR DESCRIPTION
## 🚀 Description

Add per-route `raise_for_status` flag on all decorators — `@app.get`, `@app.post`, etc. and `Router` equivalents.

When `True`, that route raises `FastHTTPBadStatusError` on 4xx/5xx instead of returning `None`. Works alongside the existing global flag — either being `True` is enough to raise.

```python
# Per-route on FastHTTP
@app.get("https://api.example.com/users", raise_for_status=True)
async def get_users(resp: Response) -> list:
    return resp.json()

# Per-route on Router
@router.post("/charge", raise_for_status=True)
async def charge(resp: Response) -> dict:
    return resp.json()

# Mix — only critical routes raise, optional ones return None
@app.get("https://api.example.com/critical", raise_for_status=True)
async def critical(resp: Response) -> dict:
    return resp.json()

@app.get("https://api.example.com/optional")
async def optional(resp: Response) -> dict | None:
    if resp is None:
        return None
    return resp.json()
```

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

### Files changed

| File | Change |
|------|--------|
| `fasthttp/client.py` | `_handle_bad_status` checks `route.raise_for_status` |
| `fasthttp/app.py` | `raise_for_status` param on all 7 decorators, passed to `Route` |
| `fasthttp/routing.py` | `raise_for_status` field on `Route`, `_RouteDef`, `Router._add_route`, all 7 `Router` decorators, `build_routes` |
| `tests/test_client.py` | 3 new tests: route=True/global=False raises, global=True/route=False raises, both False returns None |
| `examples/error/raise_for_status_per_route.py` | New example: per-route flag, global off |
| `docs/en/tutorial/response-handling.md` | Per-route usage added to `raise_for_status` section |
| `docs/en/tutorial/routers.md` | New section: `raise_for_status` on router decorators |
