### PR TITLE
Feat/auth

### DIFF
--- a/.github/scripts/download_stats.py
+++ b/.github/scripts/download_stats.py
@@ -1,0 +1,144 @@
+"""
+Fetch fasthttp-client download stats from pypistats.org + pepy.tech
+and generate a bar chart saved as stats.png.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from urllib.request import Request, urlopen
+
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+
+matplotlib.use("Agg")
+
+PACKAGE = "fasthttp-client"
+GREEN = "#34D058"
+BG = "#0d1117"
+TEXT = "#e6edf3"
+GRID = "#21262d"
+DAYS = 30
+
+
+def _fetch(url: str) -> dict:
+    req = Request(url, headers={"User-Agent": "fasthttp-stats/1.0"})
+    with urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def get_daily_downloads() -> tuple[list[str], list[int]]:
+    """Return (dates, counts) for the last DAYS days from pypistats.org."""
+    url = f"https://pypistats.org/api/packages/{PACKAGE}/overall?mirrors=false"
+    data = _fetch(url)
+    rows = sorted(data["data"], key=lambda r: r["date"])
+
+    per_date: dict[str, int] = {}
+    for row in rows:
+        d = row["date"]
+        per_date[d] = per_date.get(d, 0) + row["downloads"]
+    dates = sorted(per_date)[-DAYS:]
+    counts = [per_date[d] for d in dates]
+    return dates, counts
+
+
+def get_total_downloads() -> int:
+    """Return all-time total from pepy.tech."""
+    url = f"https://api.pepy.tech/api/v2/projects/{PACKAGE}"
+    try:
+        data = _fetch(url)
+        return int(data.get("total_downloads", 0))
+    except Exception:
+        return 0
+
+
+def format_num(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def make_chart(dates: list[str], counts: list[int], total: int) -> None:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    yesterday_downloads = counts[-1] if counts else 0
+
+    short_dates = [d[5:] for d in dates]  # MM-DD
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+    fig.patch.set_facecolor(BG)
+    ax.set_facecolor(BG)
+
+    bars = ax.bar(short_dates, counts, color=GREEN, width=0.7, zorder=3)
+
+
+    if bars:
+        bars[-1].set_color("#58e07a")
+        bars[-1].set_edgecolor("#ffffff")
+        bars[-1].set_linewidth(1.2)
+
+    ax.set_title(
+        f"📦 fasthttp-client — download stats ({today})",
+        color=TEXT,
+        fontsize=13,
+        pad=14,
+        fontweight="bold",
+    )
+    ax.set_xlabel("Date (last 30 days)", color=TEXT, fontsize=9, labelpad=8)
+    ax.set_ylabel("Downloads / day", color=TEXT, fontsize=9, labelpad=8)
+
+    ax.tick_params(colors=TEXT, labelsize=7.5)
+    ax.yaxis.set_major_formatter(mticker.FuncFormatter(lambda v, _: format_num(int(v))))
+
+
+    for i, label in enumerate(ax.get_xticklabels()):
+        label.set_visible(i % 5 == 0 or i == len(dates) - 1)
+
+    ax.spines[:].set_color(GRID)
+    ax.grid(axis="y", color=GRID, linewidth=0.6, zorder=0)
+
+
+    stats_text = (
+        f"Yesterday  {format_num(yesterday_downloads)}\n"
+        f"All-time    {format_num(total)}"
+    )
+    ax.text(
+        0.99,
+        0.97,
+        stats_text,
+        transform=ax.transAxes,
+        ha="right",
+        va="top",
+        color=TEXT,
+        fontsize=9,
+        fontfamily="monospace",
+        bbox={"boxstyle": "round,pad=0.4", "facecolor": "#161b22", "edgecolor": GRID},
+    )
+
+    plt.tight_layout()
+    plt.savefig("stats.png", dpi=150, bbox_inches="tight", facecolor=BG)
+    plt.close()
+
+    print(f"Chart saved. Yesterday: {yesterday_downloads}, Total: {total}")
+
+
+def main() -> None:
+    print("Fetching daily downloads...")
+    dates, counts = get_daily_downloads()
+    if not dates:
+        print("No data returned from pypistats.org", file=sys.stderr)
+        sys.exit(1)
+
+    print("Fetching total downloads...")
+    total = get_total_downloads()
+
+    print(f"Got {len(dates)} days of data. Total: {total}")
+    make_chart(dates, counts, total)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -2,7 +2,7 @@ name: Daily Download Stats
 
 on:
   schedule:
-    - cron: "0 9 * * *"   # every day at 09:00 UTC
+    - cron: "0 15 * * *"   # every day at 15:00 UTC (22:00 Novosibirsk UTC+7)
   workflow_dispatch:        # allow manual run
 
 jobs:

--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -1,0 +1,39 @@
+name: Daily Download Stats
+
+on:
+  schedule:
+    - cron: "0 9 * * *"   # every day at 09:00 UTC
+  workflow_dispatch:        # allow manual run
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install matplotlib requests
+
+      - name: Generate chart
+        run: python .github/scripts/download_stats.py
+
+      - name: Send chart to Telegram
+        run: |
+          YESTERDAY=$(date -d "yesterday" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d)
+          CAPTION="📦 *fasthttp-client* — daily stats (${YESTERDAY})
+
+          Chart shows downloads per day for the last 30 days.
+          [PyPI](https://pypi.org/project/fasthttp-client/) · [pepy.tech](https://pepy.tech/projects/fasthttp-client)"
+
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendPhoto" \
+            -F "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -F "photo=@stats.png" \
+            -F "caption=${CAPTION}" \
+            -F "parse_mode=Markdown"

--- a/docs/en/tutorial/authentication.md
+++ b/docs/en/tutorial/authentication.md
@@ -1,0 +1,166 @@
+# Authentication
+
+FastHTTP provides built-in authentication classes that work per route via the `auth` parameter on any decorator.
+
+## Available Auth Classes
+
+| Class | Use case |
+|-------|----------|
+| `BasicAuth(username, password)` | HTTP Basic — base64-encoded credentials |
+| `DigestAuth(username, password)` | HTTP Digest — challenge-response handshake |
+| `BearerAuth(token)` | Bearer token — OAuth2, JWT, API keys |
+
+All three are imported from `fasthttp` directly and convert to their httpx equivalents at request time.
+
+## BasicAuth
+
+Sends `Authorization: Basic <base64>` on every request to the route:
+
+```python
+from fasthttp import FastHTTP, BasicAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/profile", auth=BasicAuth("alice", "s3cr3t"))
+async def get_profile(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## DigestAuth
+
+Performs the full HTTP Digest challenge-response handshake automatically:
+
+```python
+from fasthttp import FastHTTP, DigestAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/data", auth=DigestAuth("alice", "s3cr3t"))
+async def get_data(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## BearerAuth
+
+Sends `Authorization: Bearer <token>` — use for OAuth2 access tokens, JWTs, and static API tokens:
+
+```python
+from fasthttp import FastHTTP, BearerAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/users", auth=BearerAuth("my-jwt-token"))
+async def get_users(resp: Response) -> list:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Auth on Routers
+
+The `auth` parameter works on all `Router` decorators:
+
+```python
+from fasthttp import FastHTTP, Router, BearerAuth
+from fasthttp.response import Response
+
+TOKEN = "my-service-token"
+
+app = FastHTTP()
+payments = Router(base_url="https://payments.example.com", prefix="/v1")
+
+
+@payments.post("/charge", auth=BearerAuth(TOKEN))
+async def charge(resp: Response) -> dict:
+    return resp.json()
+
+
+@payments.get("/history", auth=BearerAuth(TOKEN))
+async def history(resp: Response) -> list:
+    return resp.json()
+
+
+app.include_router(payments)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Mixing Auth Types
+
+Different routes can use different auth classes:
+
+```python
+from fasthttp import FastHTTP, BasicAuth, BearerAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://legacy.example.com/api", auth=BasicAuth("admin", "pass"))
+async def legacy(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get("https://modern.example.com/api", auth=BearerAuth("jwt-token"))
+async def modern(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## No Auth
+
+Omit `auth` (default `None`) to send no authentication headers:
+
+```python
+@app.get("https://api.example.com/public")
+async def public(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Combining with raise_for_status
+
+Auth and `raise_for_status` can be set together on the same route:
+
+```python
+from fasthttp import FastHTTP, BearerAuth
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get(
+    "https://api.example.com/secure",
+    auth=BearerAuth("my-token"),
+    raise_for_status=True,
+)
+async def secure(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"HTTP {e.status_code} on {e.url}")
+```

--- a/docs/ru/tutorial/authentication.md
+++ b/docs/ru/tutorial/authentication.md
@@ -1,0 +1,166 @@
+# Аутентификация
+
+FastHTTP предоставляет встроенные классы аутентификации, которые применяются на уровне отдельного маршрута через параметр `auth` в любом декораторе.
+
+## Доступные классы
+
+| Класс | Назначение |
+|-------|------------|
+| `BasicAuth(username, password)` | HTTP Basic — base64-кодированные учётные данные |
+| `DigestAuth(username, password)` | HTTP Digest — challenge-response рукопожатие |
+| `BearerAuth(token)` | Bearer-токен — OAuth2, JWT, API-ключи |
+
+Все три импортируются напрямую из `fasthttp` и конвертируются в эквиваленты httpx в момент запроса.
+
+## BasicAuth
+
+Отправляет заголовок `Authorization: Basic <base64>` с каждым запросом на маршрут:
+
+```python
+from fasthttp import FastHTTP, BasicAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/profile", auth=BasicAuth("alice", "s3cr3t"))
+async def get_profile(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## DigestAuth
+
+Выполняет полное HTTP Digest challenge-response рукопожатие автоматически:
+
+```python
+from fasthttp import FastHTTP, DigestAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/data", auth=DigestAuth("alice", "s3cr3t"))
+async def get_data(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## BearerAuth
+
+Отправляет заголовок `Authorization: Bearer <token>` — используется для OAuth2 access токенов, JWT и статических API-ключей:
+
+```python
+from fasthttp import FastHTTP, BearerAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://api.example.com/users", auth=BearerAuth("my-jwt-token"))
+async def get_users(resp: Response) -> list:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Auth в роутерах
+
+Параметр `auth` работает на всех декораторах `Router`:
+
+```python
+from fasthttp import FastHTTP, Router, BearerAuth
+from fasthttp.response import Response
+
+TOKEN = "my-service-token"
+
+app = FastHTTP()
+payments = Router(base_url="https://payments.example.com", prefix="/v1")
+
+
+@payments.post("/charge", auth=BearerAuth(TOKEN))
+async def charge(resp: Response) -> dict:
+    return resp.json()
+
+
+@payments.get("/history", auth=BearerAuth(TOKEN))
+async def history(resp: Response) -> list:
+    return resp.json()
+
+
+app.include_router(payments)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Разные типы auth на разных маршрутах
+
+Разные маршруты могут использовать разные классы аутентификации:
+
+```python
+from fasthttp import FastHTTP, BasicAuth, BearerAuth
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get("https://legacy.example.com/api", auth=BasicAuth("admin", "pass"))
+async def legacy(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get("https://modern.example.com/api", auth=BearerAuth("jwt-token"))
+async def modern(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Без аутентификации
+
+Без `auth` (по умолчанию `None`) заголовки аутентификации не отправляются:
+
+```python
+@app.get("https://api.example.com/public")
+async def public(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Совместно с raise_for_status
+
+`auth` и `raise_for_status` можно использовать вместе на одном маршруте:
+
+```python
+from fasthttp import FastHTTP, BearerAuth
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.get(
+    "https://api.example.com/secure",
+    auth=BearerAuth("my-token"),
+    raise_for_status=True,
+)
+async def secure(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"HTTP {e.status_code} на {e.url}")
+```

--- a/docs/ru/tutorial/configuration/settings.md
+++ b/docs/ru/tutorial/configuration/settings.md
@@ -8,17 +8,18 @@
 from fasthttp import FastHTTP
 
 app = FastHTTP(
-    debug=False,      # Режим отладки
-    http2=False,      # Использовать HTTP/2
-    proxy=None,       # Прокси сервер
-    security=True,    # Включить безопасность
-    lifespan=None,    # Обработчик запуска/завершения
-    middleware=[],    # Список middleware
-    get_request={},   # Настройки по умолчанию для GET
-    post_request={},  # Настройки по умолчанию для POST
-    put_request={},   # Настройки по умолчанию для PUT
-    patch_request={}, # Настройки по умолчанию для PATCH
-    delete_request={} # Настройки по умолчанию для DELETE
+    debug=False,             # Режим отладки
+    http2=False,             # Использовать HTTP/2
+    proxy=None,              # Прокси сервер
+    security=True,           # Включить безопасность
+    lifespan=None,           # Обработчик запуска/завершения
+    middleware=[],           # Список middleware
+    raise_for_status=False,  # Бросать исключение на 4xx/5xx
+    get_request={},          # Настройки по умолчанию для GET
+    post_request={},         # Настройки по умолчанию для POST
+    put_request={},          # Настройки по умолчанию для PUT
+    patch_request={},        # Настройки по умолчанию для PATCH
+    delete_request={}        # Настройки по умолчанию для DELETE
 )
 ```
 
@@ -32,6 +33,7 @@ app = FastHTTP(
 | `security` | `bool` | `True` | Включить функции безопасности |
 | `lifespan` | `Callable` | `None` | Обработчик запуска/завершения |
 | `middleware` | `list` | `[]` | Список middleware |
+| `raise_for_status` | `bool` | `False` | Бросать `FastHTTPBadStatusError` на 4xx/5xx для всех маршрутов |
 | `get_request` | `dict` | `{}` | Настройки GET |
 | `post_request` | `dict` | `{}` | Настройки POST |
 

--- a/docs/ru/tutorial/response-handling.md
+++ b/docs/ru/tutorial/response-handling.md
@@ -155,6 +155,52 @@ async def check_response(resp: Response) -> dict | None:
     return resp.json()
 ```
 
+### raise_for_status
+
+По умолчанию ответы 4xx и 5xx логируются, а обработчик получает `None`. Включите `raise_for_status`, чтобы вместо этого бросалось исключение `FastHTTPBadStatusError`.
+
+#### Глобально — все маршруты
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP(raise_for_status=True)
+
+
+@app.get(url="https://api.example.com/users")
+async def get_users(resp: Response) -> list:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"HTTP {e.status_code} на {e.url}")
+```
+
+#### Per-route — только конкретные маршруты
+
+```python
+app = FastHTTP()
+
+
+@app.get(url="https://api.example.com/critical", raise_for_status=True)
+async def critical(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/optional")
+async def optional(resp: Response) -> dict | None:
+    if resp is None:
+        return None
+    return resp.json()
+```
+
+`FastHTTPBadStatusError` содержит атрибуты `.status_code`, `.url`, `.method` и `.response_body`.
+
 ## Свойства ответа
 
 | Свойство | Тип | Описание |

--- a/docs/ru/tutorial/routers.md
+++ b/docs/ru/tutorial/routers.md
@@ -274,6 +274,42 @@ async def other_api(resp: Response) -> dict:
     return resp.json()
 ```
 
+## raise_for_status на маршрутах роутера
+
+`raise_for_status` можно задать на уровне конкретного маршрута через декоратор роутера. При `True` этот маршрут бросает `FastHTTPBadStatusError` на 4xx/5xx вместо возврата `None`.
+
+```python
+from fasthttp import FastHTTP, Router
+from fasthttp.exceptions import FastHTTPBadStatusError
+from fasthttp.response import Response
+
+app = FastHTTP()
+payments = Router(base_url="https://api.example.com", prefix="/payments")
+
+
+@payments.post("/charge", raise_for_status=True)
+async def charge(resp: Response) -> dict:
+    return resp.json()
+
+
+@payments.get("/history")
+async def history(resp: Response) -> dict | None:
+    if resp is None:
+        return None
+    return resp.json()
+
+
+app.include_router(payments)
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    except FastHTTPBadStatusError as e:
+        print(f"Платёж не прошёл: HTTP {e.status_code}")
+```
+
+Работает совместно с глобальным флагом `FastHTTP(raise_for_status=True)` — достаточно `True` на любом уровне.
+
 ## Когда использовать роутеры
 
 Используйте роутеры, когда в проекте есть:

--- a/fasthttp/__init__.py
+++ b/fasthttp/__init__.py
@@ -1,6 +1,7 @@
 from . import status
 from .__meta__ import __version__
 from .app import FastHTTP
+from .auth import BasicAuth, BearerAuth, DigestAuth
 from .dependencies import Depends
 from .middleware import (
     BaseMiddleware,
@@ -17,9 +18,12 @@ from .session import AsyncSession
 __all__ = (
     "AsyncSession",
     "BaseMiddleware",
+    "BasicAuth",
+    "BearerAuth",
     "CacheMiddleware",
     "CookieJar",
     "Depends",
+    "DigestAuth",
     "DummyCookieJar",
     "FastHTTP",
     "MiddlewareChain",

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
     from pydantic import BaseModel
 
+    from .auth import BasicAuth, BearerAuth, DigestAuth
     from .response import Response
     from .types import RequestsOptinal
 
@@ -578,6 +579,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
@@ -596,6 +598,7 @@ class FastHTTP:
                     tags=tags,
                     dependencies=dependencies,
                     raise_for_status=raise_for_status,
+                    auth=auth,
                     responses=responses,
                 )
             )
@@ -707,6 +710,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -718,6 +722,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -732,6 +737,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -744,6 +750,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -758,6 +765,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -770,6 +778,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -784,6 +793,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -796,6 +806,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -810,6 +821,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -822,6 +834,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -835,6 +848,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -846,6 +860,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -859,6 +874,7 @@ class FastHTTP:
         tags: list[str] | None = None,
         dependencies: list | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         return self._add_route(
@@ -870,6 +886,7 @@ class FastHTTP:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 

--- a/fasthttp/auth.py
+++ b/fasthttp/auth.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class BasicAuth:
+    """HTTP Basic authentication (username + password)."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+
+class DigestAuth:
+    """HTTP Digest authentication (username + password)."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+
+class BearerAuth:
+    """HTTP Bearer token authentication."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+
+class _HttpxBearerAuth(httpx.Auth):
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+
+def resolve_auth(
+    auth: BasicAuth | DigestAuth | BearerAuth | None,
+) -> httpx.Auth | None:
+    """Convert a fasthttp auth object to an httpx-compatible auth."""
+    if isinstance(auth, BasicAuth):
+        return httpx.BasicAuth(auth.username, auth.password)
+    if isinstance(auth, DigestAuth):
+        return httpx.DigestAuth(auth.username, auth.password)
+    if isinstance(auth, BearerAuth):
+        return _HttpxBearerAuth(auth.token)
+    return None

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -15,6 +15,7 @@ from fasthttp.security import (
 )
 
 from .__meta__ import __version__
+from .auth import resolve_auth
 from .exceptions import (
     FastHTTPBadStatusError,
     FastHTTPConnectionError,
@@ -308,6 +309,7 @@ class HTTPClient:
                 content=route.data,  # type: ignore
                 timeout=timeout_config,
                 follow_redirects=False,
+                auth=resolve_auth(route.auth),
             )
             elapsed = (time.perf_counter() - start) * 1000
             return resp, elapsed

--- a/fasthttp/routing.py
+++ b/fasthttp/routing.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from .auth import BasicAuth, BearerAuth, DigestAuth
 from .helpers.route_inspect import validate_handler
 from .helpers.routing import join_prefix as _join_prefix
 from .helpers.routing import resolve_url as _resolve_url
@@ -71,6 +72,9 @@ class Route(BaseModel):
     raise_for_status: bool = False
     """When True, raises FastHTTPBadStatusError on 4xx/5xx for this route only."""
 
+    auth: BasicAuth | DigestAuth | BearerAuth | None = None
+    """Authentication for this route (BasicAuth, DigestAuth, or BearerAuth)."""
+
     responses: dict[int, dict[Literal["model"], type[BaseModel]]] = Field(
         default_factory=dict
     )
@@ -103,6 +107,7 @@ class Route(BaseModel):
             dependencies: list[Any] | None = None,
             skip_request: bool = False,
             raise_for_status: bool = False,
+            auth: BasicAuth | DigestAuth | BearerAuth | None = None,
             responses: dict[int, dict[Literal["model"], type[BaseModel]]]
             | None = None,
         ) -> None:
@@ -118,8 +123,9 @@ class Route(BaseModel):
                 tags=tags,
                 dependencies=dependencies,
                 skip_request=skip_request,
+                raise_for_status=raise_for_status,
+                auth=auth,
                 responses=responses,
-                raise_for_status=raise_for_status
             )
 
 
@@ -139,6 +145,7 @@ class _RouteDef:
     dependencies: list[Any]
     skip_request: bool
     raise_for_status: bool
+    auth: BasicAuth | DigestAuth | BearerAuth | None
     responses: dict[int, dict[Literal["model"], type[BaseModel]]]
 
 
@@ -225,6 +232,7 @@ class Router:
         dependencies: list[Any] | None = None,
         skip_request: bool = False,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         def decorator(func: Callable[..., object]) -> Callable[..., object]:
@@ -243,6 +251,7 @@ class Router:
                     dependencies=dependencies or [],
                     skip_request=skip_request,
                     raise_for_status=raise_for_status,
+                    auth=auth,
                     responses=responses or {},
                 )
             )
@@ -260,6 +269,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a GET route on the router."""
@@ -272,6 +282,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -286,6 +297,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a POST route on the router."""
@@ -299,6 +311,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -313,6 +326,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a PUT route on the router."""
@@ -326,6 +340,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -340,6 +355,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a PATCH route on the router."""
@@ -353,6 +369,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -367,6 +384,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a DELETE route on the router."""
@@ -380,6 +398,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -393,6 +412,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering a HEAD route on the router."""
@@ -405,6 +425,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -418,6 +439,7 @@ class Router:
         tags: list[str] | None = None,
         dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
+        auth: BasicAuth | DigestAuth | BearerAuth | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
     ) -> Callable[[Callable[..., object]], Callable[..., object]]:
         """Decorator for registering an OPTIONS route on the router."""
@@ -430,6 +452,7 @@ class Router:
             tags=tags,
             dependencies=dependencies,
             raise_for_status=raise_for_status,
+            auth=auth,
             responses=responses,
         )
 
@@ -476,6 +499,7 @@ class Router:
                     dependencies=route_deps,
                     skip_request=rd.skip_request,
                     raise_for_status=rd.raise_for_status,
+                    auth=rd.auth,
                     responses=rd.responses,
                 )
             )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
         - en/tutorial/routers.md
         - en/tutorial/tags.md
         - en/tutorial/dependencies.md
+        - en/tutorial/authentication.md
         - en/tutorial/lifespan.md
       - Validation:
         - en/tutorial/validation/index.md
@@ -149,6 +150,7 @@ nav:
         - ru/tutorial/routers.md
         - ru/tutorial/tags.md
         - ru/tutorial/dependencies.md
+        - ru/tutorial/authentication.md
         - ru/tutorial/lifespan.md
       - Validation:
         - ru/tutorial/validation/index.md

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,6 +66,7 @@ ignore = [
 "tests/test_benchmark_comparison.py" = ["S101", "D103", "D104", "ANN001", "ANN201", "ANN202", "ARG001", "ARG002", "SLF001", "T201", "ANN401", "E702", "SIM108", "RUF010"]
 "examples/*"   = ["T201", "S602", "S603", "N815", "ARG001", "ARG002"]
 "fasthttp/cli/*" = ["T201"]
+".github/scripts/*" = ["T201", "S310", "BLE001", "INP001", "ICN001", "ANN", "DTZ005"]
 
 [lint.mccabe]
 max-complexity = 12

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "fasthttp-client"
-version = "1.3.11"
+version = "1.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## 🚀 Description

Add per-route authentication support via `auth` parameter on all decorators (`@app.get`, `@app.post`, etc.) and `Router` equivalents.

Three auth classes are introduced — `BasicAuth`, `DigestAuth`, and `BearerAuth` — importable directly from `fasthttp`. Under the hood they delegate to httpx's built-in auth mechanisms. A `resolve_auth()` helper converts them at request time, keeping the public API clean and independent from httpx internals.

**Usage:**
```python
from fasthttp import FastHTTP, BasicAuth, BearerAuth, DigestAuth

app = FastHTTP()

@app.get("https://api.example.com/data", auth=BearerAuth("my-token"))
async def get_data(resp: Response) -> dict:
    return resp.json()
```

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

### Files changed

| File | Change |
|------|--------|
| `fasthttp/auth.py` | New module — `BasicAuth`, `DigestAuth`, `BearerAuth`, `_HttpxBearerAuth`, `resolve_auth()` |
| `fasthttp/__init__.py` | Export `BasicAuth`, `BearerAuth`, `DigestAuth` |
| `fasthttp/routing.py` | `auth` field on `Route`, `_RouteDef`, all `Router` decorators, `build_routes()` |
| `fasthttp/app.py` | `auth` param on all `FastHTTP` decorators and `_add_route` |
| `fasthttp/client.py` | Pass `auth=resolve_auth(route.auth)` to `client.request()` |
| `docs/en/tutorial/authentication.md` | New EN doc page — BasicAuth, DigestAuth, BearerAuth, Router auth |
| `docs/ru/tutorial/authentication.md` | New RU doc page — same content in Russian |
| `mkdocs.yml` | Added `authentication.md` to EN and RU nav |

### Auth class mapping

| fasthttp class | httpx equivalent |
|----------------|-----------------|
| `BasicAuth(username, password)` | `httpx.BasicAuth` |
| `DigestAuth(username, password)` | `httpx.DigestAuth` |
| `BearerAuth(token)` | Custom `httpx.Auth` subclass — `_HttpxBearerAuth` |

`BearerAuth` requires a custom subclass because httpx has no built-in bearer auth. `_HttpxBearerAuth.auth_flow` injects `Authorization: Bearer <token>` header before yielding the request.

All 533 tests pass.
