### PR TITLE
Feat/stream

### DIFF
--- a/docs/en/tutorial/streaming.md
+++ b/docs/en/tutorial/streaming.md
@@ -1,0 +1,204 @@
+# Streaming
+
+`AsyncSession.stream()` is an async context manager for streaming HTTP responses — chunked transfers, Server-Sent Events (SSE), and any response where you want to process data as it arrives instead of waiting for the full body.
+
+## When to Use Streaming
+
+| | `session.get()` / `session.post()` | `session.stream()` |
+|---|---|---|
+| Waits for | Full response body | First byte |
+| Memory | Entire body in RAM | Chunk at a time |
+| Use case | Normal JSON / REST APIs | SSE, AI tokens, large files, live logs |
+
+Use `session.stream()` when:
+- Receiving Server-Sent Events (LLM APIs, live feeds)
+- Downloading large files without buffering
+- Processing responses line-by-line as they arrive
+
+## Basic Usage
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(security=False) as session:
+        async with session.stream("GET", "https://httpbin.org/stream/5") as resp:
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+## Signature
+
+```python
+session.stream(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    content: bytes | None = None,
+    timeout: float | None = None,
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `method` | `str` | — | HTTP method: `"GET"`, `"POST"`, etc. |
+| `url` | `str` | — | URL or relative path (resolved against `base_url`) |
+| `headers` | `dict` | `None` | Per-request headers, merged on top of session headers |
+| `content` | `bytes` | `None` | Raw bytes body (use for JSON payloads, binary data) |
+| `timeout` | `float` | session default | Override timeout in seconds |
+
+The context manager yields an `httpx.Response` in streaming mode. You can iterate it with:
+
+- `resp.aiter_lines()` — line by line (strips `\n`)
+- `resp.aiter_bytes(chunk_size)` — raw byte chunks
+- `resp.aiter_text()` — decoded text chunks
+- `await resp.aread()` — read the full body at once
+
+## Server-Sent Events (SSE)
+
+SSE streams `data: ...` lines terminated by blank lines. A common pattern used with AI APIs:
+
+```python
+import asyncio
+import json
+from fasthttp import AsyncSession
+
+
+async def main():
+    payload = json.dumps({
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": True,
+    }).encode()
+
+    async with AsyncSession(security=False, timeout=60.0) as session:
+        async with session.stream(
+            "POST",
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer YOUR_API_KEY",
+                "Content-Type": "application/json",
+            },
+            content=payload,
+        ) as resp:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                chunk = json.loads(data)
+                token = chunk["choices"][0]["delta"].get("content", "")
+                print(token, end="", flush=True)
+
+
+asyncio.run(main())
+```
+
+## Raw Bytes Body
+
+Pass any serialized payload via `content=`:
+
+```python
+import asyncio
+import json
+from fasthttp import AsyncSession
+
+
+async def main():
+    body = json.dumps({"query": "stream this"}).encode()
+
+    async with AsyncSession(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer token"},
+        security=False,
+    ) as session:
+        async with session.stream("POST", "/stream", content=body) as resp:
+            async for chunk in resp.aiter_bytes(1024):
+                process(chunk)
+
+
+asyncio.run(main())
+```
+
+## Downloading Large Files
+
+Read in chunks to avoid loading the entire file into memory:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def download(url: str, dest: str) -> None:
+    async with AsyncSession(security=False, timeout=300.0) as session:
+        async with session.stream("GET", url) as resp:
+            with open(dest, "wb") as f:
+                async for chunk in resp.aiter_bytes(8192):
+                    f.write(chunk)
+
+
+asyncio.run(download("https://example.com/large-file.zip", "file.zip"))
+```
+
+## Session Headers with Streaming
+
+Headers set on the session are automatically merged into every `stream()` call:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer token"},
+        security=False,
+    ) as session:
+        # Authorization header is included automatically
+        async with session.stream("GET", "/events") as resp:
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+Per-request `headers` are **merged on top** of session headers — they do not replace them.
+
+## Checking Status Before Reading
+
+Inspect the status code before iterating the body:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(security=False) as session:
+        async with session.stream("GET", "https://httpbin.org/stream/3") as resp:
+            if resp.status_code != 200:
+                print(f"Error: {resp.status_code}")
+                return
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+## Import
+
+```python
+from fasthttp import AsyncSession
+# or
+from fasthttp.session import AsyncSession
+```

--- a/docs/ru/tutorial/streaming.md
+++ b/docs/ru/tutorial/streaming.md
@@ -1,0 +1,204 @@
+# Стриминг
+
+`AsyncSession.stream()` — это async context manager для потоковых HTTP-ответов: chunked transfer, Server-Sent Events (SSE), и любые ответы, которые нужно обрабатывать по мере поступления данных, не дожидаясь полного тела.
+
+## Когда использовать стриминг
+
+| | `session.get()` / `session.post()` | `session.stream()` |
+|---|---|---|
+| Ждёт | Всё тело целиком | Первый байт |
+| Память | Всё тело в RAM | Чанк за чанком |
+| Когда | Обычные JSON / REST API | SSE, токены ИИ, большие файлы, live-логи |
+
+Используйте `session.stream()` когда:
+- Получаете Server-Sent Events (API языковых моделей, live-фиды)
+- Скачиваете большие файлы без буферизации
+- Обрабатываете ответ построчно по мере поступления
+
+## Базовое использование
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(security=False) as session:
+        async with session.stream("GET", "https://httpbin.org/stream/5") as resp:
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+## Сигнатура
+
+```python
+session.stream(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    content: bytes | None = None,
+    timeout: float | None = None,
+)
+```
+
+| Параметр | Тип | По умолчанию | Описание |
+|----------|-----|--------------|----------|
+| `method` | `str` | — | HTTP метод: `"GET"`, `"POST"` и т.д. |
+| `url` | `str` | — | URL или относительный путь (разрешается через `base_url`) |
+| `headers` | `dict` | `None` | Заголовки запроса, мержатся поверх заголовков сессии |
+| `content` | `bytes` | `None` | Сырое байтовое тело (JSON-payload, бинарные данные) |
+| `timeout` | `float` | дефолт сессии | Переопределить таймаут в секундах |
+
+Context manager возвращает `httpx.Response` в режиме стриминга. Итерировать можно через:
+
+- `resp.aiter_lines()` — построчно (убирает `\n`)
+- `resp.aiter_bytes(chunk_size)` — сырые байтовые чанки
+- `resp.aiter_text()` — декодированные текстовые чанки
+- `await resp.aread()` — прочитать всё тело сразу
+
+## Server-Sent Events (SSE)
+
+SSE передаёт строки `data: ...`, разделённые пустыми строками. Типичный паттерн для AI API:
+
+```python
+import asyncio
+import json
+from fasthttp import AsyncSession
+
+
+async def main():
+    payload = json.dumps({
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Привет!"}],
+        "stream": True,
+    }).encode()
+
+    async with AsyncSession(security=False, timeout=60.0) as session:
+        async with session.stream(
+            "POST",
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer YOUR_API_KEY",
+                "Content-Type": "application/json",
+            },
+            content=payload,
+        ) as resp:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                chunk = json.loads(data)
+                token = chunk["choices"][0]["delta"].get("content", "")
+                print(token, end="", flush=True)
+
+
+asyncio.run(main())
+```
+
+## Сырое байтовое тело
+
+Передавайте любой сериализованный payload через `content=`:
+
+```python
+import asyncio
+import json
+from fasthttp import AsyncSession
+
+
+async def main():
+    body = json.dumps({"query": "stream this"}).encode()
+
+    async with AsyncSession(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer token"},
+        security=False,
+    ) as session:
+        async with session.stream("POST", "/stream", content=body) as resp:
+            async for chunk in resp.aiter_bytes(1024):
+                process(chunk)
+
+
+asyncio.run(main())
+```
+
+## Скачивание больших файлов
+
+Читайте чанками, чтобы не загружать весь файл в память:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def download(url: str, dest: str) -> None:
+    async with AsyncSession(security=False, timeout=300.0) as session:
+        async with session.stream("GET", url) as resp:
+            with open(dest, "wb") as f:
+                async for chunk in resp.aiter_bytes(8192):
+                    f.write(chunk)
+
+
+asyncio.run(download("https://example.com/large-file.zip", "file.zip"))
+```
+
+## Заголовки сессии при стриминге
+
+Заголовки сессии автоматически мержатся в каждый вызов `stream()`:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer token"},
+        security=False,
+    ) as session:
+        # Заголовок Authorization включается автоматически
+        async with session.stream("GET", "/events") as resp:
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+Заголовки запроса **мержатся поверх** заголовков сессии — они их не заменяют.
+
+## Проверка статуса перед чтением
+
+Проверьте статус до итерации тела:
+
+```python
+import asyncio
+from fasthttp import AsyncSession
+
+
+async def main():
+    async with AsyncSession(security=False) as session:
+        async with session.stream("GET", "https://httpbin.org/stream/3") as resp:
+            if resp.status_code != 200:
+                print(f"Ошибка: {resp.status_code}")
+                return
+            async for line in resp.aiter_lines():
+                print(line)
+
+
+asyncio.run(main())
+```
+
+## Импорт
+
+```python
+from fasthttp import AsyncSession
+# или
+from fasthttp.session import AsyncSession
+```

--- a/fasthttp/session.py
+++ b/fasthttp/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import secrets
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, cast
 
 import httpx
@@ -20,7 +21,7 @@ from .routing import Route
 from .security import Security
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import AsyncGenerator, Callable, Coroutine
 
     from .response import Response
     from .types import HTTPMethod
@@ -330,3 +331,44 @@ class AsyncSession:
                 timeout=timeout,
             ),
         )
+
+    @asynccontextmanager
+    async def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        content: bytes | None = None,
+        timeout: float | None = None,
+    ) -> AsyncGenerator[httpx.Response, None]:
+        """Async context manager for streaming HTTP responses (SSE, chunked, etc.).
+
+        Usage:
+        ```python
+        async with session.stream("POST", "/stream", content=b"...", headers={...}) as resp:
+            async for line in resp.aiter_lines():
+                print(line)
+        ```
+        """
+        client = self._ensure_open()
+        method_upper = method.upper()
+
+        merged_headers: dict[str, str] = {}
+        if method_upper in self._request_configs:
+            merged_headers.update(self._request_configs[method_upper].get("headers", {}))
+        if headers:
+            merged_headers.update(headers)
+
+        _timeout = timeout
+        if _timeout is None and method_upper in self._request_configs:
+            _timeout = self._request_configs[method_upper].get("timeout", 30.0)
+
+        async with client.stream(
+            method_upper,
+            self._resolve_url(url),
+            headers=merged_headers or None,
+            content=content,
+            timeout=_timeout,
+        ) as resp:
+            yield resp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
         - en/tutorial/response-handling.md
         - en/tutorial/parallel-execution.md
         - en/tutorial/async-session.md
+        - en/tutorial/streaming.md
         - en/tutorial/routers.md
         - en/tutorial/tags.md
         - en/tutorial/dependencies.md
@@ -147,6 +148,7 @@ nav:
         - ru/tutorial/response-handling.md
         - ru/tutorial/parallel-execution.md
         - ru/tutorial/async-session.md
+        - ru/tutorial/streaming.md
         - ru/tutorial/routers.md
         - ru/tutorial/tags.md
         - ru/tutorial/dependencies.md


### PR DESCRIPTION
## 🚀 Description

Adds `AsyncSession.stream()` — a public async context manager for streaming HTTP responses (SSE, chunked transfer, large file downloads). Previously, streaming required accessing the private `_ensure_open()` method to get the underlying `httpx.AsyncClient` directly. This PR exposes a clean public API.

Also adds documentation for streaming in both English and Russian.

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

### New method: `AsyncSession.stream()`

```python
@asynccontextmanager
async def stream(
    self,
    method: str,
    url: str,
    *,
    headers: dict[str, str] | None = None,
    content: bytes | None = None,
    timeout: float | None = None,
) -> AsyncGenerator[httpx.Response, None]:
```

**Before** (required private API):
```python
async with AsyncSession(security=False) as session:
    raw = session._ensure_open()
    async with raw.stream("POST", url, headers=..., content=payload) as resp:
        async for line in resp.aiter_lines():
            ...
```

**After** (clean public API):
```python
async with AsyncSession(security=False) as session:
    async with session.stream("POST", url, headers=..., content=payload) as resp:
        async for line in resp.aiter_lines():
            ...
```

**Behaviour:**
- Session-level headers are merged with per-request `headers` (same behaviour as `get()`/`post()`)
- `base_url` is resolved via `_resolve_url()` — relative paths work as expected
- `timeout` falls back to the session default if not provided
- Yields raw `httpx.Response` in streaming mode — supports `aiter_lines()`, `aiter_bytes()`, `aiter_text()`, `aread()`

### Docs added
- `docs/en/tutorial/streaming.md`
- `docs/ru/tutorial/streaming.md`
- `mkdocs.yml` — both pages registered under Tutorial after `async-session`
