### PR TITLE
Feat/concurrency

### DIFF
--- a/docs/en/reference/fasthttp.md
+++ b/docs/en/reference/fasthttp.md
@@ -20,6 +20,7 @@ app = FastHTTP(
     put_request: dict = {},
     patch_request: dict = {},
     delete_request: dict = {},
+    concurrency: int = None,
 )
 ```
 
@@ -39,6 +40,7 @@ app = FastHTTP(
 | `put_request` | `dict` | `{}` | Default PUT settings |
 | `patch_request` | `dict` | `{}` | Default PATCH settings |
 | `delete_request` | `dict` | `{}` | Default DELETE settings |
+| `concurrency` | `int \| None` | `None` | Max parallel requests during `run()`. `None` = unlimited |
 
 **base_url Usage:**
 

--- a/docs/en/tutorial/parallel-execution.md
+++ b/docs/en/tutorial/parallel-execution.md
@@ -88,6 +88,62 @@ async def single_request(resp: Response) -> dict:
 app.run()
 ```
 
+## Limiting Concurrency
+
+By default, all routes run fully in parallel. Use `concurrency` to cap how many requests execute at the same time.
+
+```python
+app = FastHTTP(concurrency=5)
+```
+
+This is useful when:
+
+- The target API has a rate limit (e.g. 5 req/s)
+- You want to avoid overwhelming a server with 100+ simultaneous connections
+- You need predictable resource usage
+
+### Example
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+# At most 3 requests run at the same time
+app = FastHTTP(concurrency=3)
+
+
+@app.get(url="https://api.example.com/items/1")
+async def item_1(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/2")
+async def item_2(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/3")
+async def item_3(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/4")
+async def item_4(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/5")
+async def item_5(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    # First 3 start immediately, remaining 2 wait for a slot
+    app.run()
+```
+
+`None` (default) means no limit — all routes run in parallel.
+
 ## When Parallelism Matters
 
 Parallel execution is especially beneficial when:

--- a/docs/ru/reference/fasthttp.md
+++ b/docs/ru/reference/fasthttp.md
@@ -20,6 +20,7 @@ app = FastHTTP(
     put_request: dict = {},
     patch_request: dict = {},
     delete_request: dict = {},
+    concurrency: int = None,
 )
 ```
 
@@ -39,6 +40,7 @@ app = FastHTTP(
 | `put_request` | `dict` | `{}` | Настройки PUT |
 | `patch_request` | `dict` | `{}` | Настройки PATCH |
 | `delete_request` | `dict` | `{}` | Настройки DELETE |
+| `concurrency` | `int \| None` | `None` | Макс. параллельных запросов при `run()`. `None` = без лимита |
 
 **Использование base_url:**
 

--- a/docs/ru/tutorial/parallel-execution.md
+++ b/docs/ru/tutorial/parallel-execution.md
@@ -72,6 +72,62 @@ INFO    | fasthttp    | GET https://jsonplaceholder.typicode.com/comments/1 200 
 INFO    | fasthttp    | Done in 0.15s
 ```
 
+## Ограничение параллелизма
+
+По умолчанию все маршруты выполняются полностью параллельно. Параметр `concurrency` ограничивает количество одновременно выполняемых запросов.
+
+```python
+app = FastHTTP(concurrency=5)
+```
+
+Это полезно когда:
+
+- У целевого API есть rate limit (например, 5 req/s)
+- Нужно не перегружать сервер при 100+ одновременных соединениях
+- Требуется предсказуемое потребление ресурсов
+
+### Пример
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+# Не более 3 запросов одновременно
+app = FastHTTP(concurrency=3)
+
+
+@app.get(url="https://api.example.com/items/1")
+async def item_1(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/2")
+async def item_2(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/3")
+async def item_3(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/4")
+async def item_4(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.get(url="https://api.example.com/items/5")
+async def item_5(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    # Первые 3 стартуют сразу, остальные 2 ждут свободного слота
+    app.run()
+```
+
+`None` (по умолчанию) — без лимита, все маршруты параллельно.
+
 ## Когда это важно
 
 Параллельное выполнение особенно полезно при:

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -413,6 +413,25 @@ class FastHTTP:
                 """
             ),
         ] = "",
+        concurrency: Annotated[
+            int | None,
+            Doc(
+                """
+                Maximum number of requests to run in parallel during `run()`.
+
+                When set, FastHTTP will use a semaphore to limit how many
+                requests execute concurrently. Useful when hitting rate-limited
+                APIs or to avoid overwhelming a server.
+
+                ``None`` (default) means no limit — all routes run in parallel.
+
+                Example:
+                ```python
+                app = FastHTTP(concurrency=5)
+                ```
+                """
+            ),
+        ] = None,
     ) -> None:
         self.logger = setup_logger(debug=debug)
         self.routes: list[Route] = []
@@ -462,6 +481,8 @@ class FastHTTP:
                     self.startup_uuid = str(uuid.uuid4())
             else:
                 self.startup_uuid = str(uuid.uuid4())
+
+        self.concurrency = concurrency
 
         self.client = HTTPClient(
             self.request_configs,
@@ -1077,16 +1098,24 @@ class FastHTTP:
 
         start_all = time.perf_counter()
 
+        sem = asyncio.Semaphore(self.concurrency) if self.concurrency else None
+
         async with httpx.AsyncClient(
             http2=self.http2_enabled,
             proxy=self.proxy,
         ) as client:
+            async def _guarded(route: Route) -> tuple[Route, float, Response | None]:
+                if sem:
+                    async with sem:
+                        return await self._run_route(client, route)
+                return await self._run_route(client, route)
+
             if total > 1:
                 if sys.version_info >= (3, 11):
                     try:
                         async with asyncio.TaskGroup() as tg:
                             tg_tasks = [
-                                tg.create_task(self._run_route(client, route))
+                                tg.create_task(_guarded(route))
                                 for route in routes
                             ]
                         results = [t.result() for t in tg_tasks]
@@ -1094,13 +1123,13 @@ class FastHTTP:
                         raise eg.exceptions[0] from None
                 else:
                     results = await asyncio.gather(
-                        *[self._run_route(client, route) for route in routes]
+                        *[_guarded(route) for route in routes]
                     )
 
                 for route, elapsed, result in results:
                     self._log_result(route, elapsed, result)
             else:
-                route, elapsed, result = await self._run_route(client, routes[0])
+                route, elapsed, result = await _guarded(routes[0])
                 self._log_result(route, elapsed, result)
 
         total_time = time.perf_counter() - start_all


### PR DESCRIPTION
## 🚀 Description

Add `concurrency: int | None` parameter to `FastHTTP`. When set, limits the number of requests that execute in parallel during `app.run()` using `asyncio.Semaphore`. `None` (default) preserves existing behaviour — all routes run fully in parallel.

**Example:**
```python
app = FastHTTP(concurrency=5)  # at most 5 requests at a time
```

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

**Files changed:**

- `fasthttp/app.py` — added `concurrency` param to `FastHTTP.__init__`, stored as `self.concurrency`; `_run()` creates `asyncio.Semaphore(concurrency)` and wraps `_run_route` calls with `_guarded()` helper
- `docs/en/tutorial/parallel-execution.md` — added "Limiting Concurrency" section with example
- `docs/ru/tutorial/parallel-execution.md` — same in Russian
- `docs/en/reference/fasthttp.md` — added `concurrency` to constructor signature and parameters table
- `docs/ru/reference/fasthttp.md` — same in Russian

**Behaviour:**
- `concurrency=None` → no semaphore, all routes parallel (default, no regression)
- `concurrency=N` → semaphore with N slots; excess routes queue and start as slots free
- Works for both Python 3.11+ (`TaskGroup`) and older (`asyncio.gather`) code paths
- 533 existing tests pass
