### PR TITLE
Feat/openapi info security

### DIFF
--- a/docs/en/tutorial/openapi/swagger-ui.md
+++ b/docs/en/tutorial/openapi/swagger-ui.md
@@ -67,6 +67,92 @@ app.web_run(base_url="/api")
 
 Now the docs will be available at `http://127.0.0.1:8000/api/docs`.
 
+## Customizing API Info
+
+Pass `title`, `version`, and `description` to `FastHTTP` to control what Swagger UI shows in the header:
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP(
+    title="Payments API",
+    version="3.1.0",
+    description="""
+## Payments API
+
+Charge cards, issue refunds, and query transaction history.
+
+Markdown is **supported**.
+""",
+)
+
+
+@app.get("https://api.example.com/transactions")
+async def list_transactions(resp: Response) -> list:
+    """List recent transactions."""
+    return resp.json()
+
+
+app.web_run()
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `title` | `"FastHTTP API"` | API name shown in Swagger UI header |
+| `version` | `"1.0.0"` | Version string next to the title |
+| `description` | `""` | Markdown description below the title |
+
+## Security Schemes in Swagger UI
+
+When routes use `auth=`, FastHTTP automatically adds the corresponding security scheme to `components/securitySchemes` and attaches a lock icon to protected operations in Swagger UI.
+
+```python
+from fasthttp import FastHTTP, BearerAuth, BasicAuth
+from fasthttp.response import Response
+
+app = FastHTTP(title="Secure API", version="1.0.0")
+
+
+@app.get(
+    "https://api.example.com/profile",
+    auth=BearerAuth(token="my-token"),
+    tags=["users"],
+)
+async def get_profile(resp: Response) -> dict:
+    """Protected with Bearer token."""
+    return resp.json()
+
+
+@app.get(
+    "https://legacy.example.com/data",
+    auth=BasicAuth(username="admin", password="pass"),
+    tags=["legacy"],
+)
+async def get_legacy_data(resp: Response) -> dict:
+    """Protected with Basic auth."""
+    return resp.json()
+
+
+@app.get("https://api.example.com/status", tags=["public"])
+async def status(resp: Response) -> dict:
+    """Public — no lock icon."""
+    return resp.json()
+
+
+app.web_run()
+```
+
+FastHTTP emits the following scheme entries automatically:
+
+| Auth class | Scheme name | OpenAPI type |
+|------------|-------------|--------------|
+| `BearerAuth` | `bearerAuth` | `http / bearer / JWT` |
+| `BasicAuth` | `basicAuth` | `http / basic` |
+| `DigestAuth` | `digestAuth` | `http / digest` |
+
+Schemes are only added to the schema when at least one route uses the corresponding `auth=` class.
+
 ## With Tags
 
 ```python

--- a/docs/ru/tutorial/openapi/swagger-ui.md
+++ b/docs/ru/tutorial/openapi/swagger-ui.md
@@ -55,6 +55,92 @@ app.web_run(base_url="/api")
 
 Теперь документация будет доступна по адресу `http://127.0.0.1:8000/api/docs`.
 
+## Кастомизация информации об API
+
+Параметры `title`, `version` и `description` в `FastHTTP` управляют заголовком в Swagger UI:
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP(
+    title="Payments API",
+    version="3.1.0",
+    description="""
+## Payments API
+
+Списание средств, возвраты и история транзакций.
+
+Поддерживает **Markdown**.
+""",
+)
+
+
+@app.get("https://api.example.com/transactions")
+async def list_transactions(resp: Response) -> list:
+    """Список последних транзакций."""
+    return resp.json()
+
+
+app.web_run()
+```
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `title` | `"FastHTTP API"` | Название API в заголовке Swagger UI |
+| `version` | `"1.0.0"` | Строка версии рядом с названием |
+| `description` | `""` | Markdown-описание под заголовком |
+
+## Security Schemes в Swagger UI
+
+Если маршруты используют `auth=`, FastHTTP автоматически добавляет схему безопасности в `components/securitySchemes` и показывает значок замка на защищённых операциях.
+
+```python
+from fasthttp import FastHTTP, BearerAuth, BasicAuth
+from fasthttp.response import Response
+
+app = FastHTTP(title="Secure API", version="1.0.0")
+
+
+@app.get(
+    "https://api.example.com/profile",
+    auth=BearerAuth(token="my-token"),
+    tags=["users"],
+)
+async def get_profile(resp: Response) -> dict:
+    """Защищён Bearer-токеном."""
+    return resp.json()
+
+
+@app.get(
+    "https://legacy.example.com/data",
+    auth=BasicAuth(username="admin", password="pass"),
+    tags=["legacy"],
+)
+async def get_legacy_data(resp: Response) -> dict:
+    """Защищён Basic-аутентификацией."""
+    return resp.json()
+
+
+@app.get("https://api.example.com/status", tags=["public"])
+async def status(resp: Response) -> dict:
+    """Публичный — без замка."""
+    return resp.json()
+
+
+app.web_run()
+```
+
+FastHTTP добавляет схемы автоматически:
+
+| Класс | Имя схемы | OpenAPI тип |
+|-------|-----------|-------------|
+| `BearerAuth` | `bearerAuth` | `http / bearer / JWT` |
+| `BasicAuth` | `basicAuth` | `http / basic` |
+| `DigestAuth` | `digestAuth` | `http / digest` |
+
+Схема добавляется в документ только если хотя бы один маршрут использует соответствующий `auth=`.
+
 ## Пример
 
 ```python

--- a/examples/openapi/openapi_info_example.py
+++ b/examples/openapi/openapi_info_example.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel, Field
+
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+
+class Post(BaseModel):
+    id: int = Field(description="Post ID")
+    title: str = Field(description="Post title")
+    body: str = Field(description="Post body")
+    userId: int = Field(description="Author user ID")
+
+
+app = FastHTTP(
+    title="Blog API",
+    version="2.0.0",
+    description="""
+## Blog API
+
+Read and create blog posts via [JSONPlaceholder](https://jsonplaceholder.typicode.com).
+
+### Endpoints
+
+- **GET /posts/1** — fetch single post
+- **POST /posts** — create post
+""",
+)
+
+
+@app.get(
+    url="https://jsonplaceholder.typicode.com/posts/1",
+    response_model=Post,
+    tags=["posts"],
+)
+async def get_post(resp: Response) -> Post:
+    """Get post by ID."""
+    return Post(**resp.json())
+
+
+@app.post(
+    url="https://jsonplaceholder.typicode.com/posts",
+    json={"title": "Hello", "body": "World", "userId": 1},
+    response_model=Post,
+    tags=["posts"],
+)
+async def create_post(resp: Response) -> Post:
+    """Create a new post."""
+    return Post(**resp.json())
+
+
+if __name__ == "__main__":
+    app.web_run(port=8000)

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -413,6 +413,46 @@ class FastHTTP:
                 """
             ),
         ] = "",
+        title: Annotated[
+            str,
+            Doc(
+                """
+                Title shown in the OpenAPI schema and Swagger UI.
+
+                Example:
+                ```python
+                app = FastHTTP(title="My API")
+                ```
+                """
+            ),
+        ] = "FastHTTP API",
+        version: Annotated[
+            str,
+            Doc(
+                """
+                API version shown in the OpenAPI schema and Swagger UI.
+
+                Example:
+                ```python
+                app = FastHTTP(version="2.0.0")
+                ```
+                """
+            ),
+        ] = "1.0.0",
+        description: Annotated[
+            str,
+            Doc(
+                """
+                API description shown in the OpenAPI schema and Swagger UI.
+                Supports Markdown.
+
+                Example:
+                ```python
+                app = FastHTTP(description="My awesome API")
+                ```
+                """
+            ),
+        ] = "",
         concurrency: Annotated[
             int | None,
             Doc(
@@ -440,6 +480,9 @@ class FastHTTP:
         self.proxy = proxy
         self.base_url = base_url
         self.docs_base_url = docs_base_url
+        self.title = title
+        self.version = version
+        self.description = description
         self.generate_startup_uuid = generate_startup_uuid
         self.startup_uuid_version = startup_uuid_version
 
@@ -1386,6 +1429,9 @@ class ASGIApp:
                 schema = generate_openapi_schema(
                     self.fasthttp,
                     server_url=self.docs_urls["request_url"],
+                    title=self.fasthttp.title,
+                    version=self.fasthttp.version,
+                    description=self.fasthttp.description,
                 )
                 self._openapi_cache = orjson.dumps(schema, option=orjson.OPT_INDENT_2)
             await self._send_raw_json(send, self._openapi_cache)

--- a/fasthttp/openapi/generator.py
+++ b/fasthttp/openapi/generator.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from fasthttp.app import FastHTTP
+    from fasthttp.auth import BasicAuth, BearerAuth, DigestAuth
     from fasthttp.routing import Route
 
 
@@ -258,6 +259,40 @@ def _normalize_path(url: str) -> str:
     return api_path
 
 
+def _get_security_scheme_name(auth: BasicAuth | BearerAuth | DigestAuth) -> str:
+    """Return the securityScheme key for a given auth object."""
+    from fasthttp.auth import BasicAuth, BearerAuth, DigestAuth
+
+    if isinstance(auth, BearerAuth):
+        return "bearerAuth"
+    if isinstance(auth, BasicAuth):
+        return "basicAuth"
+    if isinstance(auth, DigestAuth):
+        return "digestAuth"
+    return "auth"
+
+
+def _collect_security_schemes(
+    routes: list[Route],
+) -> dict[str, Any]:
+    """Build components/securitySchemes from auth objects used in routes."""
+    from fasthttp.auth import BasicAuth, BearerAuth, DigestAuth
+
+    schemes: dict[str, Any] = {}
+
+    for route in routes:
+        if route.auth is None:
+            continue
+        if isinstance(route.auth, BearerAuth) and "bearerAuth" not in schemes:
+            schemes["bearerAuth"] = {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
+        elif isinstance(route.auth, BasicAuth) and "basicAuth" not in schemes:
+            schemes["basicAuth"] = {"type": "http", "scheme": "basic"}
+        elif isinstance(route.auth, DigestAuth) and "digestAuth" not in schemes:
+            schemes["digestAuth"] = {"type": "http", "scheme": "digest"}
+
+    return schemes
+
+
 def generate_openapi_schema(  # noqa: C901
     app: Annotated[
         FastHTTP,
@@ -276,6 +311,18 @@ def generate_openapi_schema(  # noqa: C901
             """
         ),
     ] = None,
+    title: Annotated[
+        str,
+        Doc("API title shown in the OpenAPI schema and Swagger UI."),
+    ] = "FastHTTP API",
+    version: Annotated[
+        str,
+        Doc("API version string."),
+    ] = "1.0.0",
+    description: Annotated[
+        str,
+        Doc("API description. Supports Markdown."),
+    ] = "",
 ) -> dict[str, Any]:
     """
     Generate OpenAPI 3.0 schema from FastHTTP application.
@@ -290,6 +337,7 @@ def generate_openapi_schema(  # noqa: C901
     routes = app.routes
 
     schemas = _collect_schemas(routes)
+    security_schemes = _collect_security_schemes(routes)
 
     paths: dict[str, Any] = {}
 
@@ -312,6 +360,10 @@ def generate_openapi_schema(  # noqa: C901
 
         if handler and hasattr(handler, "__doc__") and handler.__doc__:
             operation["description"] = _extract_docstring(handler)
+
+        if route.auth is not None:
+            scheme_name = _get_security_scheme_name(route.auth)
+            operation["security"] = [{scheme_name: []}]
 
         if route.params:
             operation["parameters"] = [
@@ -378,17 +430,19 @@ def generate_openapi_schema(  # noqa: C901
         else:
             paths[path_key] = path_item
 
+    info: dict[str, Any] = {"title": title, "version": version}
+    if description:
+        info["description"] = description
+
+    components: dict[str, Any] = {"schemas": schemas}
+    if security_schemes:
+        components["securitySchemes"] = security_schemes
+
     openapi_schema: dict[str, Any] = {
         "openapi": "3.0.3",
-        "info": {
-            "title": "FastHTTP API",
-            "description": "HTTP Client API documentation",
-            "version": "1.0.0",
-        },
+        "info": info,
         "paths": paths,
-        "components": {
-            "schemas": schemas,
-        },
+        "components": components,
     }
 
     if server_url:


### PR DESCRIPTION
## 🚀 Description

Add OpenAPI `info` customization and automatic security schemes generation.

- `FastHTTP` now accepts `title`, `version`, `description` — passed through to the OpenAPI schema and shown in Swagger UI header.
- Routes with `auth=BearerAuth/BasicAuth/DigestAuth` automatically emit the corresponding entry in `components/securitySchemes` and a per-operation `security` array with a lock icon in Swagger UI.
- Added example: `examples/openapi/openapi_info_example.py`.
- Updated docs (EN + RU): `swagger-ui.md` — new sections for info customization and security schemes.

---

## 🧩 Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] refactor: Code refactoring
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

---

## ✅ Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

**New `FastHTTP` params:**

```python
app = FastHTTP(
    title="My API",
    version="2.0.0",
    description="Markdown **supported**.",
)
```

**Security schemes (automatic, based on `auth=`):**

| Auth class | Scheme name | OpenAPI type |
|------------|-------------|--------------|
| `BearerAuth` | `bearerAuth` | `http / bearer / JWT` |
| `BasicAuth` | `basicAuth` | `http / basic` |
| `DigestAuth` | `digestAuth` | `http / digest` |

Schemes are only added when at least one route uses the corresponding `auth=` class.
