### PR TITLE
Chore/type hints and examples

### DIFF
--- a/examples/middleware/error_middleware.py
+++ b/examples/middleware/error_middleware.py
@@ -2,7 +2,7 @@ from fasthttp import FastHTTP
 from fasthttp.middleware import BaseMiddleware
 from fasthttp.response import Response
 from fasthttp.routing import Route
-from fasthttp.types import RequestsOptinal
+from fasthttp.types import RequestsOptional
 
 
 class ErrorTrackingMiddleware(BaseMiddleware):
@@ -15,7 +15,7 @@ class ErrorTrackingMiddleware(BaseMiddleware):
         self.error_count = 0
 
     async def on_error(
-        self, error: Exception, route: Route, config: RequestsOptinal
+        self, error: Exception, route: Route, config: RequestsOptional
     ) -> None:
         self.error_count += 1
         print(f"Error #{self.error_count}: {error.__class__.__name__}")

--- a/examples/oauth2/client_credentials.py
+++ b/examples/oauth2/client_credentials.py
@@ -1,0 +1,20 @@
+from fasthttp import FastHTTP, OAuth2ClientCredentials
+from fasthttp.response import Response
+
+app = FastHTTP(debug=True)
+
+auth = OAuth2ClientCredentials(
+    token_url="https://auth.example.com/oauth/token",
+    client_id="your-client-id",
+    client_secret="GAZAN",
+    scopes=["read", "write"]
+)
+
+
+@app.get("https://api.example.com/protected/resource", auth=auth)
+async def get_resource(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/oauth2/shared_auth.py
+++ b/examples/oauth2/shared_auth.py
@@ -1,0 +1,32 @@
+
+
+from fasthttp import FastHTTP, OAuth2ClientCredentials
+from fasthttp.response import Response
+
+auth = OAuth2ClientCredentials(
+    token_url= "https://auth.example.com/oauth/token",
+    client_id= "example-client",
+    client_secret="67",
+    scopes=["read", "write"],
+)
+
+app = FastHTTP(debug=True)
+
+
+@app.get("https://api.example.com/users", auth=auth)
+async def get_users(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.post("https://api.example.com/users", auth=auth, json={"name": "John"})
+async def create_user(resp: Response) -> dict:
+    return resp.json()
+
+
+@app.delete("https://api.example.com/users/1", auth=auth)
+async def delete_user(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     from .auth import BasicAuth, BearerAuth, DigestAuth, OAuth2ClientCredentials
     from .response import Response
-    from .types import RequestsOptinal
+    from .types import HTTPMethod, RequestsOptional
 
 
 class FastHTTP:
@@ -131,7 +131,7 @@ class FastHTTP:
         ] = False,
         get_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for GET requests.
@@ -144,7 +144,7 @@ class FastHTTP:
         ) = None,
         post_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for POST requests.
@@ -158,7 +158,7 @@ class FastHTTP:
         ) = None,
         put_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for PUT requests.
@@ -172,7 +172,7 @@ class FastHTTP:
         ) = None,
         patch_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                Default configuration for PATCH requests.
@@ -185,7 +185,7 @@ class FastHTTP:
         ) = None,
         delete_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for DELETE requests.
@@ -198,7 +198,7 @@ class FastHTTP:
         ) = None,
         head_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for HEAD requests.
@@ -211,7 +211,7 @@ class FastHTTP:
         ) = None,
         options_request: (
             Annotated[
-                RequestsOptinal | None,
+                RequestsOptional | None,
                 Doc(
                     """
                 Default configuration for OPTIONS requests.
@@ -368,7 +368,7 @@ class FastHTTP:
             ),
         ] = False,
         startup_uuid_version: Annotated[
-            str,
+            Literal["v4", "v7"],
             Doc(
                 """
                 The version of UUID to generate on startup if `generate_startup_uuid` is True.
@@ -642,15 +642,15 @@ class FastHTTP:
     def _add_route(
         self,
         *,
-        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+        method: HTTPMethod,
         url: str,
-        params: dict | None = None,
-        json: dict | None = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -717,7 +717,7 @@ class FastHTTP:
             ),
         ] = None,
         dependencies: Annotated[
-            list | None,
+            list[Any] | None,
             Doc(
                 """
                 Optional dependencies prepended before router dependencies.
@@ -778,11 +778,11 @@ class FastHTTP:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -804,12 +804,12 @@ class FastHTTP:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -832,12 +832,12 @@ class FastHTTP:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -860,12 +860,12 @@ class FastHTTP:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -888,12 +888,12 @@ class FastHTTP:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -916,11 +916,11 @@ class FastHTTP:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,
@@ -942,11 +942,11 @@ class FastHTTP:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list[Any] | None = None,
         raise_for_status: bool = False,
         auth: BasicAuth | DigestAuth | BearerAuth | OAuth2ClientCredentials | None = None,
         responses: dict[int, dict[Literal["model"], type[BaseModel]]] | None = None,

--- a/fasthttp/auth.py
+++ b/fasthttp/auth.py
@@ -8,6 +8,8 @@ import httpx
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from .types import OAuth2Scope
+
 
 class BasicAuth:
     """HTTP Basic authentication (username + password)."""
@@ -53,7 +55,7 @@ class OAuth2ClientCredentials:
         token_url: str,
         client_id: str,
         client_secret: str,
-        scopes: list[str] | None = None,
+        scopes: list[OAuth2Scope] | None = None,
         extra: dict[str, str] | None = None,
     ) -> None:
         self.token_url = token_url

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -44,7 +44,7 @@ class HTTPClient:
     def __init__(
         self,
         request_configs: Annotated[
-            dict,
+            dict[str, dict[str, Any]],
             Doc(
                 """
                 Dictionary mapping HTTP methods to default request configurations.

--- a/fasthttp/exceptions/base.py
+++ b/fasthttp/exceptions/base.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from annotated_doc import Doc
+
+if TYPE_CHECKING:
+    from fasthttp.types import HTTPMethod
 
 logger = logging.getLogger("fasthttp.exceptions")
 
@@ -48,7 +51,7 @@ class FastHTTPError(Exception):
         ) = None,
         method: (
             Annotated[
-                str,
+                HTTPMethod,
                 Doc(
                     """
                 HTTP method of the failed request.

--- a/fasthttp/middleware/base.py
+++ b/fasthttp/middleware/base.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
     from fasthttp.response import Response
     from fasthttp.routing import Route
-    from fasthttp.types import RequestsOptinal
+    from fasthttp.types import RequestsOptional
 
 
 class BaseMiddleware:
@@ -110,7 +110,7 @@ class BaseMiddleware:
             Doc("The route that failed."),
         ],
         config: Annotated[
-            RequestsOptinal,
+            RequestsOptional,
             Doc("Request configuration that was used."),
         ],
     ) -> Annotated[
@@ -199,7 +199,7 @@ class MiddlewareManager:
             Doc("The route being executed."),
         ],
         config: Annotated[
-            RequestsOptinal,
+            RequestsOptional,
             Doc("Initial request configuration."),
         ],
     ) -> Annotated[
@@ -226,7 +226,7 @@ class MiddlewareManager:
             Doc("The route that was executed."),
         ],
         config: Annotated[  # noqa: ARG002
-            RequestsOptinal,
+            RequestsOptional,
             Doc("Request configuration that was used."),
         ],
     ) -> Annotated[
@@ -250,7 +250,7 @@ class MiddlewareManager:
             Doc("The route that failed."),
         ],
         config: Annotated[
-            RequestsOptinal,
+            RequestsOptional,
             Doc("Request configuration that was used."),
         ],
     ) -> Annotated[

--- a/fasthttp/middleware/cache.py
+++ b/fasthttp/middleware/cache.py
@@ -22,7 +22,7 @@ except ImportError:
 if TYPE_CHECKING:
     from fasthttp.response import Response
     from fasthttp.routing import Route
-    from fasthttp.types import RequestsOptinal
+    from fasthttp.types import RequestsOptional
 
 
 class CacheEntry:
@@ -136,7 +136,7 @@ class CacheMiddleware(BaseMiddleware):
         self,
         error: Exception,  # noqa: ARG002
         route: Route,  # noqa: ARG002
-        config: RequestsOptinal,  # noqa: ARG002
+        config: RequestsOptional,  # noqa: ARG002
     ) -> None:
         key, _ = self._state.get()
         if key is not None:

--- a/fasthttp/middleware/retry.py
+++ b/fasthttp/middleware/retry.py
@@ -12,7 +12,7 @@ from .base import BaseMiddleware
 if TYPE_CHECKING:
     from fasthttp.response import Response
     from fasthttp.routing import Route
-    from fasthttp.types import RequestsOptinal
+    from fasthttp.types import RequestsOptional
 
 _retry_state: ContextVar[dict[str, Any] | None] = ContextVar(
     "retry_state", default=None
@@ -152,7 +152,7 @@ class RetryMiddleware(BaseMiddleware):
         self,
         error: Exception,
         route: Route,  # noqa: ARG002
-        config: RequestsOptinal,  # noqa: ARG002
+        config: RequestsOptional,  # noqa: ARG002
     ) -> None:
         state = _retry_state.get()
         if state is None:

--- a/fasthttp/response.py
+++ b/fasthttp/response.py
@@ -41,11 +41,11 @@ class Response:
         self,
         status: Annotated[int, Doc("HTTP status code (e.g. 200, 404, 500).")],
         text: Annotated[str, Doc("Raw response body as a string.")],
-        headers: Annotated[dict, Doc("HTTP response headers returned by the server.")],
+        headers: Annotated[dict[str, str], Doc("HTTP response headers returned by the server.")],
         method: Annotated[str | None, Doc("HTTP method used for the request.")] = None,
-        req_headers: Annotated[dict | None, Doc("HTTP headers sent with the request.")] = None,
-        query: Annotated[dict | None, Doc("Query parameters encoded into the request URL.")] = None,
-        req_json: Annotated[dict | None, Doc("JSON body sent with the request.")] = None,
+        req_headers: Annotated[dict[str, str] | None, Doc("HTTP headers sent with the request.")] = None,
+        query: Annotated[dict[str, Any] | None, Doc("Query parameters encoded into the request URL.")] = None,
+        req_json: Annotated[dict[str, Any] | None, Doc("JSON body sent with the request.")] = None,
         req_data: Annotated[object | None, Doc("Raw body or form data sent with the request.")] = None,
         content: Annotated[bytes | None, Doc("Raw response body as bytes.")] = None,
     ) -> None:
@@ -80,21 +80,21 @@ class Response:
         self._method = value
 
     @property
-    def req_headers(self) -> dict | None:
+    def req_headers(self) -> dict[str, str] | None:
         """HTTP headers sent with the request."""
         return self._req_headers
 
     @req_headers.setter
-    def req_headers(self, value: dict | None) -> None:
+    def req_headers(self, value: dict[str, str] | None) -> None:
         self._req_headers = value
 
     @property
-    def query(self) -> dict | None:
+    def query(self) -> dict[str, Any] | None:
         """Query parameters encoded into the request URL."""
         return self._query
 
     @query.setter
-    def query(self, value: dict | None) -> None:
+    def query(self, value: dict[str, Any] | None) -> None:
         self._query = value
 
     @property
@@ -111,7 +111,7 @@ class Response:
             return self._response_model.model_validate_json(self.text)  # type: ignore[union-attr]
         return orjson.loads(self.text)
 
-    def req_json(self) -> dict | None:
+    def req_json(self) -> dict[str, Any] | None:
         """Return the JSON body that was sent with the request."""
         return self._req_json
 

--- a/fasthttp/session.py
+++ b/fasthttp/session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import secrets
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 
@@ -130,7 +130,7 @@ class AsyncSession:
         )
 
         base_config = {"headers": dict(self._session_headers), "timeout": timeout}
-        self._request_configs: dict[str, dict] = {
+        self._request_configs: dict[str, dict[str, Any]] = {
             method: dict(base_config)
             for method in ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
         }
@@ -188,8 +188,8 @@ class AsyncSession:
         method: HTTPMethod,
         url: str,
         *,
-        params: dict | None = None,
-        json: dict | None = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -220,7 +220,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
     ) -> Response | None:
@@ -235,7 +235,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -251,7 +251,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -267,7 +267,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -283,7 +283,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        json: dict | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -299,7 +299,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
     ) -> Response | None:
@@ -314,7 +314,7 @@ class AsyncSession:
         self,
         url: str,
         *,
-        params: dict | None = None,
+        params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
     ) -> Response | None:
@@ -327,11 +327,11 @@ class AsyncSession:
 
     async def request(
         self,
-        method: str,
+        method: HTTPMethod,
         url: str,
         *,
-        params: dict | None = None,
-        json: dict | None = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
         data: object | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
@@ -353,7 +353,7 @@ class AsyncSession:
     @asynccontextmanager
     async def stream(
         self,
-        method: str,
+        method: HTTPMethod,
         url: str,
         *,
         headers: dict[str, str] | None = None,

--- a/fasthttp/types.py
+++ b/fasthttp/types.py
@@ -6,6 +6,20 @@ HTTPMethod: TypeAlias = Literal[
     "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"
 ]
 
+OAuth2Scope: TypeAlias = Literal[
+    "openid",
+    "profile",
+    "email",
+    "address",
+    "phone",
+    "offline_access",
+    "read",
+    "write",
+    "admin",
+    "api",
+]
+
+
 
 class JSONResponse:
     """
@@ -18,11 +32,11 @@ class JSONResponse:
     including primitive values, lists, and nested objects.
     """
 
-    Primutive: TypeAlias = str | int | float | bool | None
-    Value: TypeAlias = Primutive | list["Value"] | dict[str, "Value"]
+    Primitive: TypeAlias = str | int | float | bool | None
+    Value: TypeAlias = Primitive | list["Value"] | dict[str, "Value"]
 
 
-class RequestsOptinal(TypedDict, total=False):
+class RequestsOptional(TypedDict, total=False):
     """
     Optional request configuration.
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 """Tests for types module."""
 
-from fasthttp.types import JSONResponse, RequestsOptinal
+from fasthttp.types import JSONResponse, RequestsOptional
 
 
 class TestJSONResponse:
@@ -9,7 +9,7 @@ class TestJSONResponse:
     def test_json_response_primitive_types(self) -> None:
         """Test JSONResponse primitive type aliases."""
         # These are type aliases, so we can verify they exist
-        assert hasattr(JSONResponse, "Primutive")
+        assert hasattr(JSONResponse, "Primitive")
         assert hasattr(JSONResponse, "Value")
 
     def test_json_response_value_can_be_primitive(self) -> None:
@@ -26,30 +26,30 @@ class TestJSONResponse:
         assert "JSON response type definitions" in JSONResponse.__doc__
 
 
-class TestRequestsOptinal:
-    """Tests for RequestsOptinal TypedDict."""
+class TestRequestsOptional:
+    """Tests for RequestsOptional TypedDict."""
 
     def test_requests_optional_exists(self) -> None:
-        """Test RequestsOptinal type exists."""
-        assert RequestsOptinal is not None
+        """Test RequestsOptional type exists."""
+        assert RequestsOptional is not None
 
     def test_requests_optional_has_headers(self) -> None:
-        """Test RequestsOptinal has headers field."""
+        """Test RequestsOptional has headers field."""
         # TypedDict fields are checked at type-check time
         # We can verify the class annotations exist
-        assert "headers" in RequestsOptinal.__annotations__
+        assert "headers" in RequestsOptional.__annotations__
 
     def test_requests_optional_has_timeout(self) -> None:
-        """Test RequestsOptinal has timeout field."""
-        assert "timeout" in RequestsOptinal.__annotations__
+        """Test RequestsOptional has timeout field."""
+        assert "timeout" in RequestsOptional.__annotations__
 
     def test_requests_optional_has_allow_redirects(self) -> None:
-        """Test RequestsOptinal has allow_redirects field."""
-        assert "allow_redirects" in RequestsOptinal.__annotations__
+        """Test RequestsOptional has allow_redirects field."""
+        assert "allow_redirects" in RequestsOptional.__annotations__
 
     def test_requests_optional_can_be_created(self) -> None:
-        """Test RequestsOptinal can be instantiated with fields."""
-        config: RequestsOptinal = {
+        """Test RequestsOptional can be instantiated with fields."""
+        config: RequestsOptional = {
             "headers": {"Content-Type": "application/json"},
             "timeout": 30.0,
             "allow_redirects": True,
@@ -60,23 +60,23 @@ class TestRequestsOptinal:
         assert config["allow_redirects"] is True
 
     def test_requests_optional_partial_fields(self) -> None:
-        """Test RequestsOptinal can have partial fields (all optional)."""
-        config1: RequestsOptinal = {"timeout": 60.0}
+        """Test RequestsOptional can have partial fields (all optional)."""
+        config1: RequestsOptional = {"timeout": 60.0}
         assert config1["timeout"] == 60.0
 
-        config2: RequestsOptinal = {"headers": {"Authorization": "Bearer token"}}
+        config2: RequestsOptional = {"headers": {"Authorization": "Bearer token"}}
         assert "Authorization" in config2["headers"]
 
-        config3: RequestsOptinal = {"allow_redirects": False}
+        config3: RequestsOptional = {"allow_redirects": False}
         assert config3["allow_redirects"] is False
 
     def test_requests_optional_docstring(self) -> None:
-        """Test RequestsOptinal has proper docstring."""
-        assert RequestsOptinal.__doc__ is not None
-        assert "Optional request configuration" in RequestsOptinal.__doc__
+        """Test RequestsOptional has proper docstring."""
+        assert RequestsOptional.__doc__ is not None
+        assert "Optional request configuration" in RequestsOptional.__doc__
 
     def test_requests_optional_total_false(self) -> None:
-        """Test that RequestsOptinal has total=False (all fields optional)."""
+        """Test that RequestsOptional has total=False (all fields optional)."""
         # Verify that all fields are indeed optional by creating empty dict
-        config: RequestsOptinal = {}
+        config: RequestsOptional = {}
         assert config == {}


### PR DESCRIPTION
## 🚀 Description

### OAuth2 examples
Added `examples/oauth2/` directory with two examples: `client_credentials.py` (basic usage) and `shared_auth.py` (reusing auth across routes).

### Type hints
- `OAuth2Scope` — new Literal type alias for OAuth2 scope autocompletion in editors
- `startup_uuid_version`: `str` → `Literal["v4", "v7"]`
- `HTTPMethod` — reused instead of inline Literal in `_add_route`
- `params`/`json`: `dict` → `dict[str, Any]` (app.py + session.py)
- `dependencies`: `list` → `list[Any]` (app.py)
- `method` in session.py: `str` → `HTTPMethod` (request + stream)
- `headers`/`req_headers`: `dict` → `dict[str, str]`
- `query`/`req_json`: `dict` → `dict[str, Any]`
- `request_configs` (client.py): `dict` → `dict[str, dict[str, Any]]`
- Fixed typos: `Primutive` → `Primitive`, `RequestsOptinal` → `RequestsOptional`

### Release workflow
- `release.yml`: AI-generated release summary for Telegram and email notifications
- Email notification redesigned: light theme, "What's New" section with changelog

---

## 🧩 Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Code refactoring
- [ ] ci: CI/CD changes
- [x] chore: Maintenance

---

## ✅ Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

—

---

## 📸 Additional Context

All 559 tests pass.
