### PR TITLE
Feature/response encoding

### DIFF
--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     from .auth import BasicAuth, BearerAuth, DigestAuth, OAuth2ClientCredentials
     from .response import Response
-    from .types import HTTPMethod, RequestsOptional
+    from .types import DefaultEncoding, HTTPMethod, RequestsOptional
 
 
 class FastHTTP:
@@ -476,6 +476,30 @@ class FastHTTP:
                 """
             ),
         ] = None,
+        default_encoding: Annotated[
+            DefaultEncoding | Callable[[bytes], str],
+            Doc(
+                """
+                Default encoding for decoding response text.
+
+                Used when the response lacks a charset in Content-Type.
+                Can be a string encoding name or a callable that receives
+                the raw response bytes and returns the encoding name.
+
+                Example:
+                ```python
+                app = FastHTTP(default_encoding="cp1251")
+                ```
+
+                Custom decoder:
+                ```python
+                app = FastHTTP(
+                    default_encoding=lambda b: "utf-8" if b[:3] == b"\\xef\\xbb\\xbf" else "cp1251"
+                )
+                ```
+                """
+            ),
+        ] = "utf-8",
     ) -> None:
         self.logger = setup_logger(debug=debug)
         self.routes: list[Route] = []
@@ -530,6 +554,7 @@ class FastHTTP:
                 self.startup_uuid = str(uuid.uuid4())
 
         self.concurrency = concurrency
+        self.default_encoding = default_encoding
 
         self._ws_routes: list[dict] = []
 
@@ -1302,6 +1327,7 @@ class FastHTTP:
         async with httpx.AsyncClient(
             http2=self.http2_enabled,
             proxy=self.proxy,
+            default_encoding=self.default_encoding,
         ) as client:
             async def _guarded(route: Route) -> tuple[Route, float, Response | None]:
                 if sem:
@@ -1596,6 +1622,7 @@ class ASGIApp:
                 self._shared_client = httpx.AsyncClient(
                     http2=self.fasthttp.http2_enabled,
                     proxy=self.fasthttp.proxy,
+                    default_encoding=self.fasthttp.default_encoding,
                 )
                 await send({"type": "lifespan.startup.complete"})
             elif message["type"] == "lifespan.shutdown":

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -276,6 +276,18 @@ class HTTPClient:
     def _build_response(
         self, route: Route, config: dict, response: httpx.Response
     ) -> Response:
+        history = [
+            Response(
+                status=r.status_code,
+                text=r.text,
+                headers=dict(r.headers),
+                content=r.content,
+                http_version=r.http_version,
+                reason_phrase=r.reason_phrase,
+                elapsed=r.elapsed,
+            )
+            for r in response.history
+        ]
         resp = Response(
             status=response.status_code,
             text=response.text,
@@ -286,6 +298,10 @@ class HTTPClient:
             req_json=route.json,
             req_data=route.data,
             content=response.content,
+            history=history,
+            elapsed=response.elapsed,
+            http_version=response.http_version,
+            reason_phrase=response.reason_phrase,
         )
         resp._url = route.url  # noqa: SLF001
         return resp

--- a/fasthttp/response.py
+++ b/fasthttp/response.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import datetime
 import xml.etree.ElementTree as ET
-from typing import Annotated, Any, get_args, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
 
 import orjson
 from annotated_doc import Doc
+
+from .exceptions import FastHTTPBadStatusError
+
+if TYPE_CHECKING:
+    import httpx
 
 try:
     from fasthttp._core import extract_assets  # type: ignore
@@ -48,6 +54,11 @@ class Response:
         req_json: Annotated[dict[str, Any] | None, Doc("JSON body sent with the request.")] = None,
         req_data: Annotated[object | None, Doc("Raw body or form data sent with the request.")] = None,
         content: Annotated[bytes | None, Doc("Raw response body as bytes.")] = None,
+        *,
+        history: Annotated[list[Response] | None, Doc("List of intermediate responses from redirects.")] = None,
+        elapsed: Annotated[datetime.timedelta | None, Doc("Time taken for the request.")] = None,
+        http_version: Annotated[str | None, Doc("HTTP version used (e.g. HTTP/1.1, HTTP/2).")] = None,
+        reason_phrase: Annotated[str | None, Doc("Reason phrase (e.g. OK, Not Found).")] = None,
     ) -> None:
         self.status = status
         self.text = text
@@ -61,6 +72,10 @@ class Response:
         self._req_data = req_data
         self._url: str | None = None
         self._content: bytes | None = content
+        self._history: list[Response] = history or []
+        self._elapsed = elapsed
+        self._http_version = http_version
+        self._reason_phrase = reason_phrase
 
     def _set_url(self, url: str | None) -> None:
         self._url = url
@@ -101,6 +116,67 @@ class Response:
     def path_params(self) -> dict[str, Any]:
         """Always empty — FastHTTP does not use path parameters."""
         return {}
+
+    @property
+    def history(self) -> list[Response]:
+        """List of intermediate responses from redirects (if any)."""
+        return self._history
+
+    @property
+    def elapsed(self) -> datetime.timedelta | None:
+        """Time taken for the request."""
+        return self._elapsed
+
+    @property
+    def http_version(self) -> str | None:
+        """HTTP version used (e.g. ``HTTP/1.1``, ``HTTP/2``)."""
+        return self._http_version
+
+    @property
+    def reason_phrase(self) -> str | None:
+        """Reason phrase (e.g. ``OK``, ``Not Found``)."""
+        return self._reason_phrase
+
+    @property
+    def is_success(self) -> bool:
+        """``True`` if status code is 2xx (200-299)."""
+        return 200 <= self.status < 300
+
+    @property
+    def is_redirect(self) -> bool:
+        """``True`` if status code is 3xx (300-399)."""
+        return 300 <= self.status < 400
+
+    @property
+    def is_error(self) -> bool:
+        """``True`` if status code is 4xx or 5xx (400-599)."""
+        return 400 <= self.status < 600
+
+    @property
+    def is_client_error(self) -> bool:
+        """``True`` if status code is 4xx (400-499)."""
+        return 400 <= self.status < 500
+
+    @property
+    def is_server_error(self) -> bool:
+        """``True`` if status code is 5xx (500-599)."""
+        return 500 <= self.status < 600
+
+    @property
+    def is_informational(self) -> bool:
+        """``True`` if status code is 1xx (100-199)."""
+        return 100 <= self.status < 200
+
+    def raise_for_status(self) -> None:
+        """Raise :class:`FastHTTPBadStatusError` if status code is 4xx or 5xx."""
+        if self.is_error:
+            raise FastHTTPBadStatusError(
+                message=f"HTTP {self.status}",
+                url=self._url,
+                method=self._method,
+                status_code=self.status,
+                response_body=self.text,
+            )
 
     def json(self) -> Any:  # noqa: ANN401
         """Parse the response body as JSON, validating against response_model if set."""

--- a/fasthttp/types.py
+++ b/fasthttp/types.py
@@ -18,7 +18,10 @@ OAuth2Scope: TypeAlias = Literal[
     "admin",
     "api",
 ]
-
+DefaultEncoding: TypeAlias = Literal[
+    "utf-8", "ascii", "latin-1", "iso-8859-1", "utf-16", "cp1251",
+    "cp1252", "koi8-r", "gbk", "big5", "shift_jis", "euc-jp",
+]
 
 
 class JSONResponse:

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "fasthttp-client"
-version = "1.3.21"
+version = "1.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## 🚀 Description

Add missing `httpx.Response` metadata properties and `default_encoding` support to `FastHTTP`.

### Response
- `history` — list of intermediate redirect responses
- `elapsed` — `datetime.timedelta` with request timing
- `http_version` — protocol version string (`HTTP/1.1`, `HTTP/2`)
- `reason_phrase` — status text (`OK`, `Not Found`)
- `is_success`, `is_redirect`, `is_error`, `is_client_error`, `is_server_error`, `is_informational` — boolean status classifiers
- `raise_for_status()` — raises `FastHTTPBadStatusError` on 4xx/5xx

### FastHTTP
- `default_encoding` parameter — controls response text decoding when charset is missing
- Type: `DefaultEncoding (Literal[...]) | Callable[[bytes], str]`
- Reusable type alias `DefaultEncoding` extracted to `fasthttp/types.py`

---

## 🧩 Type of Change

- [x] feat: New feature

---

## ✅ Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

—

---

## 📸 Additional Context

All 106 existing tests pass.

### Usage examples

```python
from fasthttp import FastHTTP
from fasthttp.response import Response
from fasthttp.types import DefaultEncoding

# default_encoding
app = FastHTTP(default_encoding="cp1251")

# or custom decoder
app = FastHTTP(
    default_encoding=lambda b: "utf-8" if b[:3] == b"\xef\xbb\xbf" else "cp1251"
)

# response metadata
@app.get("https://httpbin.org/status/200")
async def example(resp: Response):
    print(resp.elapsed)          # datetime.timedelta
    print(resp.http_version)     # "HTTP/1.1"
    print(resp.reason_phrase)    # "OK"
    print(resp.history)          # []
    print(resp.is_success)       # True
    print(resp.is_error)         # False

    resp.raise_for_status()      # raises on 4xx/5xx
    return resp.json()

# status classifiers
resp = Response(status=200, text="", headers={})
resp.is_success        # True
resp.is_redirect       # False
resp.is_client_error   # False
resp.is_server_error   # False
resp.is_informational  # False
```
