### PR TITLE
Feat/file uploads

### DIFF
--- a/docs/en/tutorial/file-uploads.md
+++ b/docs/en/tutorial/file-uploads.md
@@ -1,0 +1,126 @@
+# File Uploads
+
+FastHTTP supports multipart file uploads via the `files` parameter.
+
+## Simple Upload
+
+Pass bytes directly:
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": b"Hello, world!"},
+)
+async def upload(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Upload with Filename and Content Type
+
+Provide a tuple of `(filename, data, content_type)`:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": ("report.csv", b"name,score\nAlice,95\n", "text/csv")},
+)
+async def upload_csv(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Multiple Files
+
+Pass a dictionary with multiple keys:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={
+        "avatar": ("photo.jpg", b"\xff\xd8\xff\xe0...", "image/jpeg"),
+        "document": ("resume.pdf", b"%PDF-1.4...", "application/pdf"),
+    },
+)
+async def upload_multi(resp: Response) -> dict:
+    return resp.json()
+```
+
+Or use a list to send multiple files under the same field name:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files=[
+        ("files", ("a.txt", b"content of a", "text/plain")),
+        ("files", ("b.txt", b"content of b", "text/plain")),
+    ],
+)
+async def upload_list(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Upload with JSON
+
+Combine `files` with `json` to send metadata alongside the file:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    json={"title": "My photo", "tags": ["nature"]},
+    files={"file": ("sunset.jpg", b"\xff\xd8\xff\xe0...", "image/jpeg")},
+)
+async def upload_with_meta(resp: Response) -> dict:
+    return resp.json()
+```
+
+## File Object
+
+Pass an open file handle:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": open("photo.jpg", "rb")},
+)
+async def upload_file(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Path Object
+
+Pass a `pathlib.Path`:
+
+```python
+from pathlib import Path
+
+FILE = Path("photo.jpg")
+
+
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": FILE},
+)
+async def upload_path(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Supported Types
+
+The `files` parameter accepts:
+
+| Type | Example |
+|------|---------|
+| `bytes` | `b"raw data"` |
+| `str` | `"text content"` |
+| file object | `open("file.txt", "rb")` |
+| `Path` | `Path("file.txt")` |
+| tuple `(name, data)` | `("file.txt", b"data")` |
+| tuple `(name, data, type)` | `("file.txt", b"data", "text/plain")` |
+| dict `name -> data` | `{"file": b"data"}` |
+| dict `name -> tuple` | `{"file": ("f.txt", b"data")}` |
+| list of tuples | `[("f", b"a"), ("f", b"b")]` |

--- a/docs/en/tutorial/http-methods.md
+++ b/docs/en/tutorial/http-methods.md
@@ -85,6 +85,7 @@ async def allowed_methods(resp: Response) -> dict:
 | `params` | Query parameters |
 | `json` | JSON body (for POST, PUT, PATCH) |
 | `data` | Raw bytes body |
+| `files` | File uploads (multipart/form-data) |
 | `tags` | Tags for grouping |
 | `dependencies` | List of dependencies |
 | `response_model` | Pydantic model for validation |

--- a/docs/en/tutorial/request-parameters.md
+++ b/docs/en/tutorial/request-parameters.md
@@ -85,6 +85,21 @@ async def login(resp: Response) -> dict:
     return resp.json()
 ```
 
+## File Uploads
+
+Use `files` to upload files as multipart/form-data:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": open("photo.jpg", "rb")},
+)
+async def upload(resp: Response) -> dict:
+    return resp.json()
+```
+
+See the full [File Uploads](file-uploads.md) guide for more examples.
+
 ## Combining Parameters
 
 You can combine multiple parameters:

--- a/docs/ru/tutorial/file-uploads.md
+++ b/docs/ru/tutorial/file-uploads.md
@@ -1,0 +1,126 @@
+# Загрузка файлов
+
+FastHTTP поддерживает загрузку файлов через multipart/form-data с помощью параметра `files`.
+
+## Простая загрузка
+
+Передайте байты напрямую:
+
+```python
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": b"Hello, world!"},
+)
+async def upload(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Загрузка с именем файла и типом контента
+
+Передайте кортеж `(имя_файла, данные, тип_контента)`:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": ("report.csv", b"name,score\nAlice,95\n", "text/csv")},
+)
+async def upload_csv(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Несколько файлов
+
+Передайте словарь с несколькими ключами:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={
+        "avatar": ("photo.jpg", b"\xff\xd8\xff\xe0...", "image/jpeg"),
+        "document": ("resume.pdf", b"%PDF-1.4...", "application/pdf"),
+    },
+)
+async def upload_multi(resp: Response) -> dict:
+    return resp.json()
+```
+
+Или используйте список для отправки нескольких файлов под одним именем поля:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files=[
+        ("files", ("a.txt", b"содержимое a", "text/plain")),
+        ("files", ("b.txt", b"содержимое b", "text/plain")),
+    ],
+)
+async def upload_list(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Загрузка с JSON
+
+Сочетайте `files` с `json` для отправки метаданных вместе с файлом:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    json={"title": "Моё фото", "tags": ["природа"]},
+    files={"file": ("sunset.jpg", b"\xff\xd8\xff\xe0...", "image/jpeg")},
+)
+async def upload_with_meta(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Файловый объект
+
+Передайте открытый файловый дескриптор:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": open("photo.jpg", "rb")},
+)
+async def upload_file(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Path объект
+
+Передайте `pathlib.Path`:
+
+```python
+from pathlib import Path
+
+FILE = Path("photo.jpg")
+
+
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": FILE},
+)
+async def upload_path(resp: Response) -> dict:
+    return resp.json()
+```
+
+## Поддерживаемые типы
+
+Параметр `files` принимает:
+
+| Тип | Пример |
+|-----|--------|
+| `bytes` | `b"данные"` |
+| `str` | `"текст"` |
+| файловый объект | `open("file.txt", "rb")` |
+| `Path` | `Path("file.txt")` |
+| кортеж `(имя, данные)` | `("file.txt", b"data")` |
+| кортеж `(имя, данные, тип)` | `("file.txt", b"data", "text/plain")` |
+| словарь `имя -> данные` | `{"file": b"data"}` |
+| словарь `имя -> кортеж` | `{"file": ("f.txt", b"data")}` |
+| список кортежей | `[("f", b"a"), ("f", b"b")]` |

--- a/docs/ru/tutorial/http-methods.md
+++ b/docs/ru/tutorial/http-methods.md
@@ -77,6 +77,21 @@ async def allowed_methods(resp: Response) -> dict:
     return {"allow": resp.headers.get("allow", "")}
 ```
 
+## Параметры декоратора
+
+| Параметр | Описание |
+|----------|----------|
+| `url` | URL запроса (обязательный) |
+| `params` | Query параметры |
+| `json` | JSON тело (для POST, PUT, PATCH) |
+| `data` | Сырые байты |
+| `files` | Загрузка файлов (multipart/form-data) |
+| `tags` | Теги для группировки |
+| `dependencies` | Список зависимостей |
+| `response_model` | Модель Pydantic для валидации |
+| `request_model` | Модель Pydantic для валидации запроса |
+| `responses` | Модели Pydantic для ответов с ошибками |
+
 ## Возвращаемые значения
 
 Обработчики могут возвращать разные типы:

--- a/docs/ru/tutorial/request-parameters.md
+++ b/docs/ru/tutorial/request-parameters.md
@@ -84,3 +84,18 @@ async def with_headers(resp: Response) -> dict:
 async def slow_request(resp: Response) -> dict:
     return resp.json()
 ```
+
+## Загрузка файлов
+
+Используйте `files` для загрузки файлов как multipart/form-data:
+
+```python
+@app.post(
+    url="https://api.example.com/upload",
+    files={"file": open("photo.jpg", "rb")},
+)
+async def upload(resp: Response) -> dict:
+    return resp.json()
+```
+
+Подробное руководство см. в разделе [Загрузка файлов](file-uploads.md).

--- a/examples/files/simple_upload.py
+++ b/examples/files/simple_upload.py
@@ -1,0 +1,16 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files={"file": b"Hello, world!"},
+)
+async def upload_bytes(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_file_object.py
+++ b/examples/files/upload_file_object.py
@@ -1,0 +1,16 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files={"file": open(__file__, "rb")},
+)
+async def upload_open_file(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_list.py
+++ b/examples/files/upload_list.py
@@ -1,0 +1,19 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files=[
+        ("files", ("a.txt", b"content of a", "text/plain")),
+        ("files", ("b.txt", b"content of b", "text/plain")),
+    ],
+)
+async def upload_list(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_multiple.py
+++ b/examples/files/upload_multiple.py
@@ -1,0 +1,19 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files={
+        "avatar": ("photo.jpg", b"\xff\xd8\xff\xe0fake-jpeg", "image/jpeg"),
+        "document": ("resume.pdf", b"%PDF-1.4 fake-pdf", "application/pdf"),
+    },
+)
+async def upload_multiple(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_path.py
+++ b/examples/files/upload_path.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+FILE = Path(__file__).parent / "sample.txt"
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files={"file": FILE},
+)
+async def upload_path(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_router.py
+++ b/examples/files/upload_router.py
@@ -1,0 +1,20 @@
+from fasthttp import FastHTTP, Router
+from fasthttp.response import Response
+
+router = Router(base_url="https://httpbin.org", prefix="/api")
+
+
+@router.post(
+    url="/upload",
+    files={"file": b"Hello from router!"},
+)
+async def upload(resp: Response) -> dict:
+    return resp.json()
+
+
+app = FastHTTP()
+app.include_router(router)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_with_filename.py
+++ b/examples/files/upload_with_filename.py
@@ -1,0 +1,16 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    files={"file": ("report.csv", b"name,score\nAlice,95\nBob,87\n", "text/csv")},
+)
+async def upload_with_meta(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/files/upload_with_json.py
+++ b/examples/files/upload_with_json.py
@@ -1,0 +1,17 @@
+from fasthttp import FastHTTP
+from fasthttp.response import Response
+
+app = FastHTTP()
+
+
+@app.post(
+    url="https://httpbin.org/post",
+    json={"title": "My photo", "tags": ["nature", "sunset"]},
+    files={"file": ("sunset.jpg", b"\xff\xd8\xff\xe0fake-jpeg", "image/jpeg")},
+)
+async def upload_with_json(resp: Response) -> dict:
+    return resp.json()
+
+
+if __name__ == "__main__":
+    app.run()

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     from .auth import BasicAuth, BearerAuth, DigestAuth, OAuth2ClientCredentials
     from .response import Response
-    from .types import DefaultEncoding, HTTPMethod, RequestsOptional
+    from .types import DefaultEncoding, FileUpload, HTTPMethod, RequestsOptional
 
 
 class FastHTTP:
@@ -561,7 +561,7 @@ class FastHTTP:
         self.event_hooks = EventHooks()
 
         self.client = HTTPClient(
-            self.request_configs,
+            self.request_configs, # type: ignore
             self.logger,
             self.middleware_manager,
             self.security,
@@ -672,6 +672,7 @@ class FastHTTP:
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -691,6 +692,7 @@ class FastHTTP:
                     params=params,
                     json=json,
                     data=data,
+                    files=files,
                     response_model=response_model,
                     request_model=request_model,
                     tags=tags,
@@ -804,6 +806,7 @@ class FastHTTP:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -816,6 +819,7 @@ class FastHTTP:
             method="GET",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -831,6 +835,7 @@ class FastHTTP:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -844,6 +849,7 @@ class FastHTTP:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -859,6 +865,7 @@ class FastHTTP:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -872,6 +879,7 @@ class FastHTTP:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -887,6 +895,7 @@ class FastHTTP:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -900,6 +909,7 @@ class FastHTTP:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -915,6 +925,7 @@ class FastHTTP:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -928,6 +939,7 @@ class FastHTTP:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -942,6 +954,7 @@ class FastHTTP:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -954,6 +967,7 @@ class FastHTTP:
             method="HEAD",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -968,6 +982,7 @@ class FastHTTP:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -980,6 +995,7 @@ class FastHTTP:
             method="OPTIONS",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -338,6 +338,7 @@ class HTTPClient:
                 params=config.get("params", route.params),
                 json=route.json,
                 content=route.data,  # type: ignore
+                files=route.files,  # type: ignore
                 timeout=timeout_config,
                 follow_redirects=False,
                 auth=resolve_auth(route.auth),

--- a/fasthttp/routing.py
+++ b/fasthttp/routing.py
@@ -11,7 +11,7 @@ from .events import ErrorHook, EventHooks, RequestHook, ResponseHook
 from .helpers.route_inspect import validate_handler
 from .helpers.routing import join_prefix as _join_prefix
 from .helpers.routing import resolve_url as _resolve_url
-from .types import HTTPMethod  # noqa: TC001
+from .types import FileUpload, HTTPMethod  # noqa: TC001
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -54,6 +54,9 @@ class Route(BaseModel):
 
     data: object | None = None
     """Raw body or form data sent with the request."""
+
+    files: FileUpload | None = None
+    """Files to upload as multipart/form-data."""
 
     response_model: type | None = None
     """Optional Pydantic model for validating the handler result."""
@@ -102,6 +105,7 @@ class Route(BaseModel):
             params: dict[str, Any] | None = None,
             json: dict[str, Any] | None = None,
             data: object | None = None,
+            files: FileUpload | None = None,
             response_model: type | None = None,
             request_model: type[BaseModel] | None = None,
             tags: list[str] | None = None,
@@ -119,6 +123,7 @@ class Route(BaseModel):
                 params=params,
                 json=json,
                 data=data,
+                files=files,
                 response_model=response_model,
                 request_model=request_model,
                 tags=tags,
@@ -140,6 +145,7 @@ class _RouteDef:
     params: dict[str, Any] | None
     json: dict[str, Any] | None
     data: object | None
+    files: FileUpload | None
     response_model: type[BaseModel] | None
     request_model: type[BaseModel] | None
     tags: list[str]
@@ -228,6 +234,7 @@ class Router:
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -247,6 +254,7 @@ class Router:
                     params=params,
                     json=json,
                     data=data,
+                    files=files,
                     response_model=response_model,
                     request_model=request_model,
                     tags=tags or [],
@@ -266,6 +274,7 @@ class Router:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -279,6 +288,7 @@ class Router:
             method="GET",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -294,6 +304,7 @@ class Router:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -308,6 +319,7 @@ class Router:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -323,6 +335,7 @@ class Router:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -337,6 +350,7 @@ class Router:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -352,6 +366,7 @@ class Router:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -366,6 +381,7 @@ class Router:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -381,6 +397,7 @@ class Router:
         *,
         json: dict[str, Any] | None = None,
         data: object | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -395,6 +412,7 @@ class Router:
             url=url,
             json=json,
             data=data,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -409,6 +427,7 @@ class Router:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -422,6 +441,7 @@ class Router:
             method="HEAD",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -436,6 +456,7 @@ class Router:
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        files: FileUpload | None = None,
         response_model: type[BaseModel] | None = None,
         request_model: type[BaseModel] | None = None,
         tags: list[str] | None = None,
@@ -449,6 +470,7 @@ class Router:
             method="OPTIONS",
             url=url,
             params=params,
+            files=files,
             response_model=response_model,
             request_model=request_model,
             tags=tags,
@@ -548,6 +570,7 @@ class Router:
                     params=rd.params,
                     json=rd.json,
                     data=rd.data,
+                    files=rd.files,
                     response_model=rd.response_model,
                     request_model=rd.request_model,
                     tags=route_tags,

--- a/fasthttp/types.py
+++ b/fasthttp/types.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import io
+from os import PathLike
 from typing import Annotated, Literal, TypeAlias, TypedDict
 
 from annotated_doc import Doc
@@ -84,3 +88,17 @@ class RequestsOptional(TypedDict, total=False):
             """
         ),
     ]
+
+
+FileContent: TypeAlias = bytes | str | io.IOBase | io.RawIOBase | io.BufferedIOBase | io.TextIOBase | PathLike[str]
+
+FileTuple: TypeAlias = tuple[str, FileContent] | tuple[str, FileContent, str] | tuple[str, FileContent, str, dict[str, str]]
+
+FileUpload: TypeAlias = (
+    FileContent
+    | FileTuple
+    | dict[str, FileContent]
+    | dict[str, FileTuple]
+    | list[tuple[str, FileContent]]
+    | list[tuple[str, FileTuple]]
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
         - en/tutorial/first-steps.md
         - en/tutorial/http-methods.md
         - en/tutorial/request-parameters.md
+        - en/tutorial/file-uploads.md
         - en/tutorial/response-handling.md
         - en/tutorial/parallel-execution.md
         - en/tutorial/async-session.md
@@ -147,6 +148,7 @@ nav:
         - ru/tutorial/first-steps.md
         - ru/tutorial/http-methods.md
         - ru/tutorial/request-parameters.md
+        - ru/tutorial/file-uploads.md
         - ru/tutorial/response-handling.md
         - ru/tutorial/parallel-execution.md
         - ru/tutorial/async-session.md


### PR DESCRIPTION
## 🚀 Description

Added file upload support (`files=`) at the decorator level and in the `Route` model. Files can now be uploaded via `@app.post(files=...)`, `@app.put(files=...)`, etc. Implemented by passing the `files` parameter through to `httpx.AsyncClient.request()`.

---

## 🧩 Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] refactor: Code refactoring
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

---

## ✅ Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

---

## 📸 Additional Context

### Changed Files

**Code:**
- `fasthttp/types.py` — added `FileContent`, `FileTuple`, `FileUpload` types
- `fasthttp/routing.py` — `files` field in `Route`, `_RouteDef`; `files=` parameter in all `Router` decorators
- `fasthttp/app.py` — `files=` parameter in all `FastHTTP` decorators
- `fasthttp/client.py` — `files=route.files` in `httpx.AsyncClient.request()`

**Documentation:**
- `docs/en/tutorial/file-uploads.md` — new page (EN)
- `docs/ru/tutorial/file-uploads.md` — new page (RU)
- `docs/en/tutorial/http-methods.md` — added `files` row to decorator parameters table
- `docs/ru/tutorial/http-methods.md` — added decorator parameters table with `files`
- `docs/en/tutorial/request-parameters.md` — added "File Uploads" section
- `docs/ru/tutorial/request-parameters.md` — added "Загрузка файлов" section
- `mkdocs.yml` — added new pages to navigation

**Examples:**
- `examples/files/` — 8 examples (simple, tuple, multiple, list, json+files, path, file object, router)

### Usage

```python
from fasthttp import FastHTTP
from fasthttp.response import Response

app = FastHTTP()

@app.post(
    url="https://httpbin.org/post",
    files={"file": ("report.csv", b"name,score\nAlice,95\n", "text/csv")},
)
async def upload(resp: Response) -> dict:
    return resp.json()

app.run()
```
