### PR TITLE
Feat Exception Handlers

### DIFF
--- a/docs/en/middleware.md
+++ b/docs/en/middleware.md
@@ -267,9 +267,35 @@ async def track_error(error, route):
     print(f"✖ {error} on {route.url}")
 ```
 
+### `exception_handler`
+
+FastAPI-style handler for a specific exception type. Unlike `on_error`, its return value **replaces the route's result** instead of the request failing silently — the request is "recovered" rather than just logged.
+
+```python
+from fasthttp.exceptions import FastHTTPTimeoutError
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def handle_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+```
+
+The handler receives `(route, exc)` — same order as FastAPI's `(request, exc)`. If several handlers match (through inheritance), the most specific registered type wins:
+
+```python
+@app.exception_handler(Exception)
+async def fallback(route, exc):
+    return {"error": "unexpected"}
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def timeout(route, exc):
+    return {"error": "timeout"}  # wins for FastHTTPTimeoutError, fallback still applies to everything else
+```
+
+Only exceptions that actually propagate out of a request reach a handler — for HTTP status errors this means the route (or the app) must have `raise_for_status=True`, otherwise `FastHTTPBadStatusError` is never raised and there's nothing to intercept.
+
 ### With Router
 
-Event hooks on a router are merged into the app via `include_router()`:
+Event hooks on a router, including `exception_handler`, are merged into the app via `include_router()`:
 
 ```python
 from fasthttp import FastHTTP, Router
@@ -280,9 +306,13 @@ router = Router(base_url="https://api.example.com")
 async def router_hook(route, config):
     print(f"[router] → {route.url}")
 
+@router.exception_handler(FastHTTPTimeoutError)
+async def router_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+
 app = FastHTTP()
 app.include_router(router)
-# router_hook will run for all requests from this router
+# both hooks will run for all requests from this router
 ```
 
 ### With AsyncSession
@@ -297,6 +327,8 @@ async with AsyncSession() as session:
 
     resp = await session.get("https://api.example.com")
 ```
+
+`exception_handler` is only available on `FastHTTP` and `Router` — `AsyncSession` does not support it, since it returns responses directly to the caller instead of routing through handlers.
 
 ### Middleware vs Event Hooks
 

--- a/docs/en/reference/fasthttp.md
+++ b/docs/en/reference/fasthttp.md
@@ -155,6 +155,33 @@ Decorator for GraphQL.
 )
 ```
 
+### exception_handler()
+
+Decorator registering a handler for a specific exception type, FastAPI-style. The handler's return value replaces the route's result instead of the request failing silently.
+
+```python
+@app.exception_handler(
+    exc_type: type[Exception],
+)
+```
+
+**Parameters:**
+- `exc_type` - exception class this handler should be invoked for
+
+**Handler signature:** `async def handler(route, exc) -> Any`
+
+**Example:**
+
+```python
+from fasthttp.exceptions import FastHTTPTimeoutError
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def handle_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+```
+
+Also available on `Router` via `@router.exception_handler(...)`. See [Event Hooks](../middleware.md#event-hooks) for `on_request`, `on_response`, `on_error`, and MRO-based dispatch details.
+
 ## AsyncSession
 
 Imperative async HTTP client — like `httpx.AsyncClient`. Returns responses directly instead of logging them.

--- a/docs/ru/middleware.md
+++ b/docs/ru/middleware.md
@@ -267,9 +267,35 @@ async def track_error(error, route):
     print(f"✖ {error} на {route.url}")
 ```
 
+### `exception_handler`
+
+Обработчик для конкретного типа исключения, в стиле FastAPI. В отличие от `on_error`, возвращаемое значение **заменяет результат route** вместо того, чтобы запрос просто тихо падал — запрос "восстанавливается", а не только логируется.
+
+```python
+from fasthttp.exceptions import FastHTTPTimeoutError
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def handle_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+```
+
+Хендлер принимает `(route, exc)` — тот же порядок, что и `(request, exc)` в FastAPI. Если под исключение подходит несколько зарегистрированных хендлеров (через наследование), побеждает самый специфичный:
+
+```python
+@app.exception_handler(Exception)
+async def fallback(route, exc):
+    return {"error": "unexpected"}
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def timeout(route, exc):
+    return {"error": "timeout"}  # сработает для FastHTTPTimeoutError, fallback — для всего остального
+```
+
+До хендлера доходят только исключения, которые реально "вылетают" из запроса — для HTTP-статусов это значит, что у route (или у приложения) должен быть включён `raise_for_status=True`, иначе `FastHTTPBadStatusError` вообще не поднимается и перехватывать нечего.
+
 ### С Router
 
-Event hooks роутера мержатся в приложение через `include_router()`:
+Event hooks роутера, включая `exception_handler`, мержатся в приложение через `include_router()`:
 
 ```python
 from fasthttp import FastHTTP, Router
@@ -280,9 +306,13 @@ router = Router(base_url="https://api.example.com")
 async def router_hook(route, config):
     print(f"[router] → {route.url}")
 
+@router.exception_handler(FastHTTPTimeoutError)
+async def router_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+
 app = FastHTTP()
 app.include_router(router)
-# router_hook будет вызываться для всех запросов этого роутера
+# оба хука будут вызываться для всех запросов этого роутера
 ```
 
 ### С AsyncSession
@@ -297,6 +327,8 @@ async with AsyncSession() as session:
 
     resp = await session.get("https://api.example.com")
 ```
+
+`exception_handler` доступен только на `FastHTTP` и `Router` — `AsyncSession` его не поддерживает, так как возвращает ответы напрямую вызывающему коду, а не маршрутизирует их через хендлеры.
 
 ### Middleware vs Event Hooks
 

--- a/docs/ru/reference/fasthttp.md
+++ b/docs/ru/reference/fasthttp.md
@@ -101,6 +101,33 @@ app.include_router(
 
 Декоратор для GraphQL.
 
+### exception_handler()
+
+Декоратор, регистрирующий хендлер для конкретного типа исключения, в стиле FastAPI. Возвращаемое значение хендлера заменяет результат route вместо того, чтобы запрос просто тихо падал.
+
+```python
+@app.exception_handler(
+    exc_type: type[Exception],
+)
+```
+
+**Параметры:**
+- `exc_type` - класс исключения, для которого вызывается этот хендлер
+
+**Сигнатура хендлера:** `async def handler(route, exc) -> Any`
+
+**Пример:**
+
+```python
+from fasthttp.exceptions import FastHTTPTimeoutError
+
+@app.exception_handler(FastHTTPTimeoutError)
+async def handle_timeout(route, exc):
+    return {"error": "timeout", "url": route.url}
+```
+
+Также доступен на `Router` через `@router.exception_handler(...)`. См. [Event Hooks](../middleware.md#event-hooks) для `on_request`, `on_response`, `on_error` и деталей диспетчеризации по MRO.
+
 ## AsyncSession
 
 Императивный async HTTP-клиент — аналог `httpx.AsyncClient`. Возвращает ответы напрямую вместо логирования.

--- a/fasthttp/app.py
+++ b/fasthttp/app.py
@@ -14,7 +14,7 @@ from websockets import connect as ws_connect
 from websockets.exceptions import ConnectionClosed as WSConnClosed
 
 from .client import HTTPClient
-from .events import ErrorHook, EventHooks, RequestHook, ResponseHook
+from .events import ErrorHook, EventHooks, ExceptionHandler, RequestHook, ResponseHook
 from .graphql.client import create_graphql_client
 from .helpers.route_inspect import (
     check_annotated_parameters,
@@ -1385,6 +1385,32 @@ class FastHTTP:
         """
         self.event_hooks.on_error(func)
         return func
+
+    def exception_handler(
+        self,
+        exc_type: Annotated[
+            type[Exception],
+            Doc("Exception class this handler should be invoked for."),
+        ],
+    ) -> Callable[[ExceptionHandler], ExceptionHandler]:
+        """
+        Register a handler for a specific exception type, FastAPI-style.
+
+        When a route raises an exception matching ``exc_type`` (or one of
+        its subclasses, resolved via MRO), the handler runs instead of the
+        request simply failing. Its return value becomes the route's
+        result, just like a normal route handler's return value.
+
+        Signature: ``async def handler(route: Route, exc: Exception) -> Any``
+
+        Example:
+            ```python
+            @app.exception_handler(FastHTTPTimeoutError)
+            async def handle_timeout(route, exc):
+                return {"error": "timeout", "url": route.url}
+            ```
+        """
+        return self.event_hooks.exception_handler(exc_type=exc_type)
 
     def _log_result(
         self, route: Route, elapsed: float, result: Response | None

--- a/fasthttp/client.py
+++ b/fasthttp/client.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Annotated, Any
 from urllib.parse import urljoin
 
@@ -320,6 +321,19 @@ class HTTPClient:
         response._handler_result = handler_result  # noqa: SLF001
         return response
 
+    async def _run_exception_handler(
+        self,
+        handler: Callable[..., Coroutine[Any, Any, object]],
+        route: Route,
+        exc: Exception,
+    ) -> Response:
+        if self.security:
+            self.security.release_slot()
+        handler_result = await handler(route, exc)
+        response = Response(status=0, text="", headers={}, method=route.method)
+        response._url = route.url  # noqa: SLF001
+        return await self._process_handler_result(response, handler_result)
+
     async def _execute_request(
         self,
         client: httpx.AsyncClient,
@@ -585,12 +599,22 @@ class HTTPClient:
                 if attempt < max_attempts - 1:
                     continue
                 return None
-            except FastHTTPError:
+            except FastHTTPError as e:
+                handler = (
+                    self.event_hooks.get_exception_handler(e)
+                    if self._has_event_hooks
+                    else None
+                )
+                if handler is not None:
+                    return await self._run_exception_handler(handler, route, e)
                 raise
             except Exception as e:  # noqa: BLE001
                 last_error = e
                 if self._has_event_hooks:
                     await self.event_hooks.process_error(e, route)
+                    handler = self.event_hooks.get_exception_handler(e)
+                    if handler is not None:
+                        return await self._run_exception_handler(handler, route, e)
                 if self.middleware_manager:
                     try:
                         await self.middleware_manager.process_on_error(

--- a/fasthttp/events.py
+++ b/fasthttp/events.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 RequestHook = Callable[..., Coroutine[Any, Any, None]]
 ResponseHook = Callable[..., Coroutine[Any, Any, None]]
 ErrorHook = Callable[..., Coroutine[Any, Any, None]]
+ExceptionHandler = Callable[..., Coroutine[Any, Any, Any]]
 
 
 class EventHooks:
@@ -26,12 +27,14 @@ class EventHooks:
     - ``on_request``: ``async def hook(route: Route, config: dict) -> None``
     - ``on_response``: ``async def hook(response: Response) -> None``
     - ``on_error``: ``async def hook(error: Exception, route: Route) -> None``
+    - ``exception_handler``: ``async def handler(route: Route, exc: Exception) -> Any``
     """
 
     def __init__(self) -> None:
         self._on_request: list[RequestHook] = []
         self._on_response: list[ResponseHook] = []
         self._on_error: list[ErrorHook] = []
+        self._exception_handlers: dict[type[Exception], ExceptionHandler] = {}
 
     def on_request(
         self,
@@ -102,6 +105,49 @@ class EventHooks:
         self._on_error.append(func)
         return func
 
+    def exception_handler(
+        self,
+        *,
+        exc_type: Annotated[
+            type[Exception],
+            Doc("Exception class this handler should be invoked for."),
+        ],
+    ) -> Callable[[ExceptionHandler], ExceptionHandler]:
+        """
+        Register a handler for a specific exception type.
+
+        Unlike ``on_error``, the handler's return value replaces the
+        route's result instead of the request failing silently. The most
+        specific registered type (by MRO) wins when an exception matches
+        several registered handlers.
+
+        Signature: ``async def handler(route: Route, exc: Exception) -> Any``
+
+        Example:
+            ```python
+            @app.exception_handler(FastHTTPTimeoutError)
+            async def handle_timeout(route, exc):
+                return {"error": "timeout", "url": route.url}
+            ```
+        """
+
+        def decorator(func: ExceptionHandler) -> ExceptionHandler:
+            self._exception_handlers[exc_type] = func
+            return func
+
+        return decorator
+
+    def get_exception_handler(
+        self,
+        exc: Annotated[Exception, Doc("The exception to find a handler for.")],
+    ) -> ExceptionHandler | None:
+        """Return the most specific registered handler for ``exc``, if any."""
+        for exc_type in type(exc).__mro__:
+            handler = self._exception_handlers.get(exc_type)
+            if handler is not None:
+                return handler
+        return None
+
     async def process_request(
         self,
         route: Annotated[Route, Doc("The route being executed.")],
@@ -130,3 +176,4 @@ class EventHooks:
         self._on_request.extend(other._on_request)
         self._on_response.extend(other._on_response)
         self._on_error.extend(other._on_error)
+        self._exception_handlers.update(other._exception_handlers)

--- a/fasthttp/routing.py
+++ b/fasthttp/routing.py
@@ -12,7 +12,7 @@ from .auth import (  # noqa: TC001
     DigestAuth,
     OAuth2ClientCredentials,
 )
-from .events import ErrorHook, EventHooks, RequestHook, ResponseHook
+from .events import ErrorHook, EventHooks, ExceptionHandler, RequestHook, ResponseHook
 from .helpers.route_inspect import validate_handler
 from .helpers.routing import join_prefix as _join_prefix
 from .helpers.routing import resolve_url as _resolve_url
@@ -111,7 +111,7 @@ class Route(BaseModel):
             json: dict[str, Any] | None = None,
             data: object | None = None,
             files: FileUpload | None = None,
-            response_model: Any = None,
+            response_model: Any = None,  # noqa: ANN401
             request_model: type[BaseModel] | None = None,
             tags: list[str] | None = None,
             dependencies: list[Any] | None = None,
@@ -537,6 +537,24 @@ class Router:
         """
         self.event_hooks.on_error(func)
         return func
+
+    def exception_handler(
+        self,
+        exc_type: type[Exception],
+    ) -> Callable[[ExceptionHandler], ExceptionHandler]:
+        """
+        Register a handler for a specific exception type, FastAPI-style.
+
+        Example:
+            ```python
+            router = Router(base_url="https://api.example.com")
+
+            @router.exception_handler(FastHTTPTimeoutError)
+            async def handle_timeout(route, exc):
+                return {"error": "timeout", "url": route.url}
+            ```
+        """
+        return self.event_hooks.exception_handler(exc_type=exc_type)
 
     def build_routes(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -568,3 +568,38 @@ class TestFastHTTPLogResult:
         # Just verify it doesn't crash
         app._log_result(route, 100.5, None)
         assert True
+
+
+class TestFastHTTPExceptionHandler:
+    """Tests for the exception_handler decorator on FastHTTP."""
+
+    def test_exception_handler_registers_in_event_hooks(self) -> None:
+        """Test that exception_handler stores the handler keyed by exception type."""
+        app = FastHTTP()
+
+        @app.exception_handler(ValueError)
+        async def handle_value_error(route, exc):
+            return {"error": str(exc)}
+
+        assert app.event_hooks.get_exception_handler(ValueError("boom")) is handle_value_error
+
+    def test_exception_handler_returns_original_func(self) -> None:
+        """Test that the decorator doesn't wrap or replace the function."""
+        app = FastHTTP()
+
+        async def handle_value_error(route, exc):
+            return None
+
+        decorated = app.exception_handler(ValueError)(handle_value_error)
+
+        assert decorated is handle_value_error
+
+    def test_exception_handler_no_match_returns_none(self) -> None:
+        """Test that an unregistered exception type resolves to no handler."""
+        app = FastHTTP()
+
+        @app.exception_handler(ValueError)
+        async def handle_value_error(route, exc):
+            return None
+
+        assert app.event_hooks.get_exception_handler(KeyError("x")) is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from fasthttp.__meta__ import __version__
 from fasthttp.client import HTTPClient
+from fasthttp.events import EventHooks
 from fasthttp.exceptions import FastHTTPBadStatusError
 from fasthttp.middleware import MiddlewareManager as MM  # noqa: N817
 from fasthttp.response import Response
@@ -510,6 +512,145 @@ class TestHTTPClient:
             handler=handler,
             raise_for_status=False,
         )
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is None
+
+
+class TestExceptionHandler:
+    """Tests for the exception_handler dispatch in HTTPClient.send()."""
+
+    @pytest.mark.asyncio
+    async def test_handler_result_replaces_default_none_on_generic_exception(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """A registered handler's return value replaces the usual None result."""
+        mock_httpx_client.request = AsyncMock(
+            side_effect=httpx.ConnectError("Connection failed")
+        )
+
+        event_hooks = EventHooks()
+
+        @event_hooks.exception_handler(exc_type=httpx.ConnectError)
+        async def handle_connect_error(route, exc):
+            return {"error": str(exc), "url": route.url}
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            event_hooks=event_hooks,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/", handler=handler)
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is not None
+        assert result._handler_result == {
+            "error": "Connection failed",
+            "url": "http://example.com/",
+        }
+
+    @pytest.mark.asyncio
+    async def test_handler_replaces_bad_status_error_when_raise_for_status(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """A handler for FastHTTPBadStatusError intercepts it instead of raising."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.headers = {}
+        mock_response.content = b"Internal Server Error"
+
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        event_hooks = EventHooks()
+
+        @event_hooks.exception_handler(exc_type=FastHTTPBadStatusError)
+        async def handle_bad_status(route, exc):
+            return {"status": exc.status_code}
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            raise_for_status=True,
+            event_hooks=event_hooks,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/error", handler=handler)
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is not None
+        assert result._handler_result == {"status": 500}
+
+    @pytest.mark.asyncio
+    async def test_most_specific_handler_wins_via_mro(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """When both a base and a specific handler are registered, the specific one wins."""
+        mock_httpx_client.request = AsyncMock(
+            side_effect=httpx.ConnectError("boom")
+        )
+
+        event_hooks = EventHooks()
+
+        @event_hooks.exception_handler(exc_type=Exception)
+        async def generic(route, exc):
+            return "generic"
+
+        @event_hooks.exception_handler(exc_type=httpx.ConnectError)
+        async def specific(route, exc):
+            return "specific"
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            event_hooks=event_hooks,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/", handler=handler)
+
+        result = await client.send(mock_httpx_client, route)
+
+        assert result is not None
+        assert result._handler_result == "specific"
+
+    @pytest.mark.asyncio
+    async def test_unhandled_exception_type_still_returns_none(
+        self, mock_logger, request_configs, mock_httpx_client
+    ) -> None:
+        """No matching handler falls back to prior behavior (None)."""
+        mock_httpx_client.request = AsyncMock(
+            side_effect=httpx.TimeoutException("slow")
+        )
+
+        event_hooks = EventHooks()
+
+        @event_hooks.exception_handler(exc_type=httpx.ConnectError)
+        async def handle_connect_error(route, exc):
+            return "should not be called"
+
+        client = HTTPClient(
+            request_configs=request_configs,
+            logger=mock_logger,
+            event_hooks=event_hooks,
+        )
+
+        async def handler(response) -> Response:
+            return response
+
+        route = Route(method="GET", url="http://example.com/", handler=handler)
 
         result = await client.send(mock_httpx_client, route)
 

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ wheels = [
 
 [[package]]
 name = "fasthttp-client"
-version = "1.3.27"
+version = "1.3.28"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## 🚀 Description
Adds FastAPI-style `exception_handler` decorators to `FastHTTP`, `Router`, and `EventHooks`. When a route raises an exception matching a registered type (or one of its subclasses, resolved via MRO), the handler runs and its return value becomes the route's result instead of the request simply failing.

---

## 🧩 Type of Change

Please select **one**:

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code refactoring
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

---

## ✅ Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes
- [x] Code follows project style

---

## 🔗 Related Issues

Fixes #

---

## 📸 Additional Context

- New `ExceptionHandler` type and `exception_handler`/`get_exception_handler` API in `fasthttp/events.py`.
- `HTTPClient._run_exception_handler` invokes the matching handler and processes its result like a normal handler result.
- Exposed via `FastHTTP.exception_handler` and `Router.exception_handler`.
- Docs updated in `docs/en/middleware.md`, `docs/en/reference/fasthttp.md`, and Russian equivalents.
- Tests added in `tests/test_app.py` and `tests/test_client.py`.

<!--
IMPORTANT:
PR title should follow Conventional Commits:
feat: add new router
fix: resolve async bug
docs: update README
-->
